### PR TITLE
Add missing comma, reorder examples

### DIFF
--- a/054_Query_DSL/70_Important_clauses.asciidoc
+++ b/054_Query_DSL/70_Important_clauses.asciidoc
@@ -7,15 +7,15 @@ the most important queries and filters.
 
 ==== `term` filter
 
-The `term` filter is used to filter by exact values, be they numbers, dates
+The `term` filter is used to filter by exact values, be they numbers, dates,
 booleans, or `not_analyzed` exact value string fields:
 
 [source,js]
 --------------------------------------------------
 { "term": { "age":    26           }}
 { "term": { "date":   "2014-09-01" }}
-{ "term": { "tag":    "full_text"  }}
 { "term": { "public": true         }}
+{ "term": { "tag":    "full_text"  }}
 --------------------------------------------------
 // SENSE: 054_Query_DSL/70_Term_filter.json
 
@@ -137,7 +137,7 @@ the search:
 --------------------------------------------------
 // SENSE: 054_Query_DSL/70_Match_query.json
 
-If you use it on a field containing an exact value, such as a date, a number,
+If you use it on a field containing an exact value, such as a number, a date,
 a boolean or a `not_analyzed` string field, then it will search for that
 exact value:
 
@@ -145,8 +145,8 @@ exact value:
 --------------------------------------------------
 { "match": { "age":    26           }}
 { "match": { "date":   "2014-09-01" }}
-{ "match": { "tag":    "full_text"  }}
 { "match": { "public": true         }}
+{ "match": { "tag":    "full_text"  }}
 --------------------------------------------------
 // SENSE: 054_Query_DSL/70_Match_query.json
 


### PR DESCRIPTION
I think it is more readable when examples follow the same order as the related text.
