### PR TITLE
Fixed request example for Scan and scroll

### DIFF
--- a/060_Distributed_Search/20_Scan_and_scroll.asciidoc
+++ b/060_Distributed_Search/20_Scan_and_scroll.asciidoc
@@ -48,11 +48,7 @@ results:
 
 [source,js]
 --------------------------------------------------
-GET /_search/scroll?scroll=1m <1>
-c2Nhbjs1OzExODpRNV9aY1VyUVM4U0NMd2pjWlJ3YWlBOzExOTpRNV9aY1VyUVM4U0
-NMd2pjWlJ3YWlBOzExNjpRNV9aY1VyUVM4U0NMd2pjWlJ3YWlBOzExNzpRNV9aY1Vy
-UVM4U0NMd2pjWlJ3YWlBOzEyMDpRNV9aY1VyUVM4U0NMd2pjWlJ3YWlBOzE7dG90YW
-xfaGl0czoxOw==
+GET /_search/scroll?scroll_id=c2Nh...Ow==&scroll=1m <1>
 --------------------------------------------------
 <1> Keep the scroll open for another minute.
 


### PR DESCRIPTION
Scroll uses the scroll_id as a parameter, not as body (which doesn't work with GET anyway).

I shortened the parameter value to keep it short, so I hope "..." won't cause any issues when generating the docs, which was a bit too much to set up for a small correction.

Let me know if I should change anything.
