### PR TITLE
Fixes typo

### DIFF
--- a/052_Mapping_Analysis/40_Analysis.asciidoc
+++ b/052_Mapping_Analysis/40_Analysis.asciidoc
@@ -80,7 +80,7 @@ rules of English grammar.
 +
 The `english` analyzer would produce the following:
 +
-    set, shape, semi, transpar, call, set_tran, 5
+    set, shape, semi, transpar, call, set_trans, 5
 +
 Note how `"transparent"` and `"calling"` have been stemmed to their root form.
 


### PR DESCRIPTION
`set_trans` was not stemmed, so `set_tran` is a typo.
