### PR TITLE
Update 45_Mapping.asciidoc

### DIFF
--- a/052_Mapping_Analysis/45_Mapping.asciidoc
+++ b/052_Mapping_Analysis/45_Mapping.asciidoc
@@ -55,7 +55,7 @@ of this chapter>> we already retrieved the mapping for type `tweet` in index
 
 [source,js]
 --------------------------------------------------
-GET /gb/_mapping/tweet
+GET /gb/tweet/_mapping
 --------------------------------------------------
 
 This shows us the mapping for the fields (called _properties_) that


### PR DESCRIPTION
Perhaps the api changed; for me `/gb/_mapping/tweet` is not found, but this works `/gb/tweet/_mapping`.
