### PR TITLE
Added missing Query DSL snippets to 010_Intro

### DIFF
--- a/snippets/010_Intro/30_Query_DSL.json
+++ b/snippets/010_Intro/30_Query_DSL.json
@@ -48,3 +48,39 @@ GET /megacorp/employee/_search
         }
     }
 }
+
+# Find all employees who enjoy "rock" or "climbing"
+GET /megacorp/employee/_search
+{
+    "query" : {
+        "match" : {
+            "about" : "rock climbing"
+        }
+    }
+}
+
+# Find all employees who enjoy "rock climbing"
+GET /megacorp/employee/_search
+{
+    "query" : {
+        "match_phrase" : {
+            "about" : "rock climbing"
+        }
+    }
+}
+
+# Find all employees who enjoy "rock climbing"
+# and highlight the matches
+GET /megacorp/employee/_search
+{
+    "query" : {
+        "match_phrase" : {
+            "about" : "rock climbing"
+        }
+    },
+    "highlight": {
+        "fields" : {
+            "about" : {}
+        }
+    }
+}


### PR DESCRIPTION
Added missing Query DSL searches which are already contained in the examples of the introduction but not yet in the snippets.
