### PR TITLE
Fixed typo in 75_Queries_with_filters.asciidoc

### DIFF
--- a/054_Query_DSL/75_Queries_with_filters.asciidoc
+++ b/054_Query_DSL/75_Queries_with_filters.asciidoc
@@ -1,7 +1,7 @@
 === Combining queries with filters
 
-Queries can be used in _query context_ and filters can be used
-in _filter context_.  Throughout the Elasticsearch API you will see parameters
+Queries can be used in _query contexts_ and filters can be used
+in _filter contexts_.  Throughout the Elasticsearch API you will see parameters
 with `query` or `filter` in the name.  These
 expect a single argument containing either a single query or filter clause
 respectively. In other words, they establish the


### PR DESCRIPTION
Fixed plural of "context".
