### PR TITLE
Update 30_Controlling_analysis.asciidoc

### DIFF
--- a/100_Full_Text_Search/30_Controlling_analysis.asciidoc
+++ b/100_Full_Text_Search/30_Controlling_analysis.asciidoc
@@ -38,7 +38,7 @@ GET /my_index/_analyze?field=my_type.title   <1>
 Foxes
 
 GET /my_index/_analyze?field=my_type.english_title <2>
-Foxes
+Fox
 --------------------------------------------------
 // SENSE: 100_Full_Text_Search/30_Analysis.json
 


### PR DESCRIPTION
The comment below the example, seems to suggest that the analyzer should return the term "fox" instead of "foxes" for the english analyzer.

Unless I've misunderstood.
