### PR TITLE
fix typos

### DIFF
--- a/120_Proximity_Matching/15_Multi_value_fields.asciidoc
+++ b/120_Proximity_Matching/15_Multi_value_fields.asciidoc
@@ -65,8 +65,8 @@ PUT /my_index/_mapping/groups <2>
 --------------------------------------------------
 // SENSE: 120_Proximity_Matching/15_Multi_value_fields.json
 
-<1> First delete the `group` mapping and and documents of that type.
-<2> Then create a new `group` mapping with the correct values.
+<1> First delete the `groups` mapping and and documents of that type.
+<2> Then create a new `groups` mapping with the correct values.
 
 The `position_offset_gap` settings tells Elasticsearch that it should increase
 the current term `position` by the specified value for every new array


### PR DESCRIPTION
adjust type mentioned in the text to "groups" as previously used
