### PR TITLE
add missing dot to end sentence

### DIFF
--- a/210_Identifying_words/40_ICU_tokenizer.asciidoc
+++ b/210_Identifying_words/40_ICU_tokenizer.asciidoc
@@ -8,7 +8,7 @@ Japanese, and Korean, and using custom rules to break Myanmar and Khmer text
 into syllables.
 
 For instance, compare the tokens produced by the `standard` and
-`icu_tokenizers` respectively when tokenizing ``Hello. I am from Bangkok'' in
+`icu_tokenizers` respectively when tokenizing ``Hello. I am from Bangkok.'' in
 Thai:
 
 [source,js]


### PR DESCRIPTION
I suppose the dot was not omitted on purpose because in a paragraph below the same sentence is cited including the dot.
