### PR TITLE
Document Oriented - JSON example is invalid

### DIFF
--- a/010_Intro/20_Document.asciidoc
+++ b/010_Intro/20_Document.asciidoc
@@ -39,7 +39,7 @@ Consider this JSON document which represents a user object:
         "age":         25,
         "interests": [ "dolphins", "whales" ]
     },
-    "join_date": "2014/05/01",
+    "join_date": "2014/05/01"
 }
 --------------------------------------------------
 


### PR DESCRIPTION
Trailing comma make the JSON invalid
