### PR TITLE
Fix typo:  node name

### DIFF
--- a/040_Distributed_CRUD/15_Create_index_delete.asciidoc
+++ b/040_Distributed_CRUD/15_Create_index_delete.asciidoc
@@ -13,7 +13,7 @@ Below we list the sequence of steps necessary to successfully create, index or
 delete a document on both the primary and any replica shards, as depicted in
 <<img-distrib-write>>:
 
-1. The client sends a create, index or delete request to `Node_1`.
+1. The client sends a create, index or delete request to `Node 1`.
 
 2. The node uses the document's `_id` to determine that the document
    belongs to shard `0`. It forwards the request to `Node 3`,

--- a/040_Distributed_CRUD/25_Partial_updates.asciidoc
+++ b/040_Distributed_CRUD/25_Partial_updates.asciidoc
@@ -9,7 +9,7 @@ image::images/04-04_update.png["Partial updates to a document"]
 Below we list the sequence of steps used to perform a partial update on  a
 document, as depicted in <<img-distrib-update>>:
 
-1. The client sends an update request to `Node_1`.
+1. The client sends an update request to `Node 1`.
 
 2. It forwards the request to `Node 3`, where the primary shard is allocated.
 

--- a/040_Distributed_CRUD/30_Bulk_requests.asciidoc
+++ b/040_Distributed_CRUD/30_Bulk_requests.asciidoc
@@ -17,7 +17,7 @@ image::images/04-05_mget.png["Retrieving multiple documents with mget"]
 Below we list the sequence of steps necessary to retrieve multiple documents
 with a single `mget` request, as depicted in <<img-distrib-mget>>:
 
-1. The client sends an `mget` request to `Node_1`.
+1. The client sends an `mget` request to `Node 1`.
 
 2. `Node 1` builds a multi-get request per shard, and forwards these
    requests in parallel to the nodes hosting each required primary or replica
@@ -34,7 +34,7 @@ Below we list the sequence of steps necessary to execute multiple
 `create`, `index`, `delete` and `update` requests within a single
 `bulk` request, as depicted in <<img-distrib-bulk>>:
 
-1. The client sends a `bulk` request to `Node_1`.
+1. The client sends a `bulk` request to `Node 1`.
 
 2. `Node 1` builds a bulk request per shard, and forwards these requests in
     parallel to the nodes hosting each involved primary shard.


### PR DESCRIPTION
In Chapter 4, some typo in  the sequence of steps
