### PR TITLE
reword upsert parameter explanation

### DIFF
--- a/030_Data/45_Partial_update.asciidoc
+++ b/030_Data/45_Partial_update.asciidoc
@@ -167,8 +167,8 @@ that a user views a page, we increment the counter for that page.  But if it
 is a new page, we can't be sure that the counter already exists. If we try to
 update a non-existent document, the update will fail.
 
-In cases like these, we can use the `upsert` parameter to specify the
-document that should be created if it doesn't already exist:
+In cases like these, we can use the `upsert` parameter to specify that the
+document should be created if it doesn't already exist:
 
 [source,js]
 --------------------------------------------------


### PR DESCRIPTION
What does the upsert parameter specify?  It doesn't specify "the
document".  The URL specifies "the document".  It instead specifies
"that the document should be created" (or drop the conjunction "that"
between the two clauses as allowed in technical writing).
