### PR TITLE
Getting `Parse Failure` with guide's example

### DIFF
--- a/120_Proximity_Matching/10_Slop.asciidoc
+++ b/120_Proximity_Matching/10_Slop.asciidoc
@@ -14,8 +14,10 @@ GET /my_index/my_type/_search
 {
     "query": {
         "match_phrase": {
-            "title": "quick fox",
-            "slop":  1
+            "title": {
+            	"query": "quick fox",
+            	"slop":  1
+            }
         }
     }
 }


### PR DESCRIPTION
Looks like the example on this guide's page and the corresponding request snippet in Sense (after `# Proximity query with slop - matches` in `120_Proximity_Matching/10_Slop.json`) differs slightly in their syntax.

With the example from the guide I get `Parse Failure`.
