### PR TITLE
Use correct HTTP method for node shutdown

### DIFF
--- a/520_Post_Deployment/40_rolling_restart.asciidoc
+++ b/520_Post_Deployment/40_rolling_restart.asciidoc
@@ -42,7 +42,7 @@ machine:
 +
 [source,js]
 ----
-PUT /_cluster/nodes/_local/_shutdown
+POST /_cluster/nodes/_local/_shutdown
 ----
 
 4. Perform maintenance/upgrade


### PR DESCRIPTION
The Shutdown API uses POST, not PUT. See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/cluster-nodes-shutdown.html
