### PR TITLE
Update 45_Partial_update.asciidoc

### DIFF
--- a/030_Data/45_Partial_update.asciidoc
+++ b/030_Data/45_Partial_update.asciidoc
@@ -99,7 +99,8 @@ blog post has had:
 --------------------------------------------------
 POST /website/blog/1/_update
 {
-   "script" : "ctx._source.views+=1"
+   "script" : "ctx._source.views+=1",
+   "lang":"groovy"
 }
 --------------------------------------------------
 // SENSE: 030_Data/45_Partial_update.json
@@ -116,6 +117,7 @@ another tag:
 POST /website/blog/1/_update
 {
    "script" : "ctx._source.tags+=new_tag",
+   "lang":"groovy",
    "params" : {
       "new_tag" : "search"
    }
@@ -153,6 +155,7 @@ by setting `ctx.op` to `delete`:
 POST /website/blog/1/_update
 {
    "script" : "ctx.op = ctx._source.views == count ? 'delete' : 'none'",
+   "lang":"groovy",
     "params" : {
         "count": 1
     }
@@ -175,6 +178,7 @@ document that should be created if it doesn't already exist:
 POST /website/pageviews/1/_update
 {
    "script" : "ctx._source.views+=1",
+   "lang":"groovy",
    "upsert": {
        "views": 1
    }
@@ -215,6 +219,7 @@ to `0`.
 POST /website/pageviews/1/_update?retry_on_conflict=5 <1>
 {
    "script" : "ctx._source.views+=1",
+   "lang":"groovy",
    "upsert": {
        "views": 0
    }


### PR DESCRIPTION
If we do not add  "lang":"groovy",  we will get the error : {
   "error": "ElasticsearchIllegalArgumentException[failed to execute script]; nested: ScriptException[dynamic scripting for [mvel] disabled]; ",
   "status": 400
}
If we include lang parameter, and give value as, (lang=groovy) we do not get the issue 

http://stackoverflow.com/questions/25345260/why-am-i-getting-an-error-in-my-elasticsearch-query-after-upgrading-to-1-3-2
