### PR TITLE
Update to show correct results

### DIFF
--- a/052_Mapping_Analysis/45_Mapping.asciidoc
+++ b/052_Mapping_Analysis/45_Mapping.asciidoc
@@ -278,7 +278,7 @@ name. Compare the output of these two requests:
 [source,js]
 --------------------------------------------------
 GET /gb/_analyze?field=tweet
-Black-cats <1>
+black, cat <1>
 
 GET /gb/_analyze?field=tag
 Black-cats <1>


### PR DESCRIPTION
According to Sense, analyzing the mapping of the `tweet` field should return two tokens, not one.