### PR TITLE
Update 40_Analysis.asciidoc

### DIFF
--- a/052_Mapping_Analysis/40_Analysis.asciidoc
+++ b/052_Mapping_Analysis/40_Analysis.asciidoc
@@ -159,8 +159,7 @@ parameters,  and the text to analyze in the body:
 
 [source,js]
 --------------------------------------------------
-GET /_analyze?analyzer=standard
-Text to analyze
+GET /_analyze?analyzer=standard&text=Text to analyze
 --------------------------------------------------
 // SENSE: 052_Mapping_Analysis/40_Analyze.json
 


### PR DESCRIPTION
The example for the text analyzer does not works with the current syntax, that is

[source,js]
--------------------------------------------------
GET /_analyze?analyzer=standard
Text to analyze
--------------------------------------------------

I propose the following modification to make the example working on sense.

[source,js]
--------------------------------------------------
GET /_analyze?analyzer=standard&text=Text to analyze
--------------------------------------------------