### PR TITLE
Update 60_Query_DSL.asciidoc

### DIFF
--- a/054_Query_DSL/60_Query_DSL.asciidoc
+++ b/054_Query_DSL/60_Query_DSL.asciidoc
@@ -78,7 +78,6 @@ The full search request would look like this:
 
 [source,js]
 --------------------------------------------------
-GET /_search
 {
     "query": {
         "match": {


### PR DESCRIPTION
I suggest to remove the GET query from the example. I also checked on sense and i returns an error for GET queries with body

[source,js]
--------------------------------------------------
GET /_search
{
    "query": {
        "match": {
            "tweet": "elasticsearch"
        }
    }
}
--------------------------------------------------
// SENSE: 054_Query_DSL/60_Match_query.json