### PR TITLE
Update 30_Controlling_analysis.asciidoc

### DIFF
--- a/100_Full_Text_Search/30_Controlling_analysis.asciidoc
+++ b/100_Full_Text_Search/30_Controlling_analysis.asciidoc
@@ -35,10 +35,8 @@ analyzed at index time by using the `analyze` API to analyze the word `Foxes`:
 [source,js]
 --------------------------------------------------
 GET /my_index/_analyze?field=my_type.title   <1>
-Foxes
 
-GET /my_index/_analyze?field=my_type.english_title <2>
-Foxes
+GET /my_index/_analyze?field=my_type.english_title&text=Foxes <2>
 --------------------------------------------------
 // SENSE: 100_Full_Text_Search/30_Analysis.json
 


### PR DESCRIPTION
I think that the way how examples are done is not runnable if we are doing copy and paste using sense.
I'd like to use the document format

```
GET /my_index/_analyze?field=my_type.title   
{
    "Foxes"
}
```

or the query based format

```
GET /my_index/_analyze?field=my_type.title&text=Foxes   
```