### PR TITLE
Update 15_API.asciidoc

### DIFF
--- a/010_Intro/15_API.asciidoc
+++ b/010_Intro/15_API.asciidoc
@@ -25,7 +25,7 @@ not be able to form a cluster.
 
 [TIP]
 ====
-The Java client must be from the same version of Elasticsearch as the nodes;
+The Java client must be from the same _major_ version of Elasticsearch as the nodes;
 otherwise, they may not be able to understand each other.
 ====
 


### PR DESCRIPTION
Client can talk to a cluster as long as they are the same major version (at least es >= 1.0.0 ), right?