### PR TITLE
Fix reference to "exists" instead of "found" in 15_Get.asciidoc

### DIFF
--- a/030_Data/15_Get.asciidoc
+++ b/030_Data/15_Get.asciidoc
@@ -94,7 +94,7 @@ filtered out the `date` field:
   "_type" :    "blog",
   "_id" :      "123",
   "_version" : 1,
-  "exists" :   true,
+  "found" :   true,
   "_source" : {
       "title": "My first blog entry" ,
       "text":  "Just trying this out..."


### PR DESCRIPTION
Already updated in the rest of the doc, but I guess this one escaped :smile: 