### PR TITLE
Update 35_Search_as_you_type.asciidoc

### DIFF
--- a/130_Partial_Matching/35_Search_as_you_type.asciidoc
+++ b/130_Partial_Matching/35_Search_as_you_type.asciidoc
@@ -14,7 +14,7 @@ will call the `autocomplete_filter`:
 {
     "filter": {
         "autocomplete_filter": {
-            "type":     "edge_ngram",
+            "type":     "edgeNGram",
             "min_gram": 1,
             "max_gram": 20
         }


### PR DESCRIPTION
Is the keyword "edge_ngram" a typo?
In the [Edge NGram Tokenizer](https://www.elastic.co/guide/en/elasticsearch/guide/current/_ngrams_for_partial_matching.html) documentation the edge ngram is declared as "edgeNGram"