### PR TITLE
Use POST with query DSL example

### DIFF
--- a/010_Intro/30_Tutorial_Search.asciidoc
+++ b/010_Intro/30_Tutorial_Search.asciidoc
@@ -180,7 +180,7 @@ We can represent the previous search for all Smiths like so:
 
 [source,js]
 --------------------------------------------------
-GET /megacorp/employee/_search
+POST /megacorp/employee/_search
 {
     "query" : {
         "match" : {
@@ -206,7 +206,7 @@ which allows us to execute structured searches efficiently:
 
 [source,js]
 --------------------------------------------------
-GET /megacorp/employee/_search
+POST /megacorp/employee/_search
 {
     "query" : {
         "filtered" : {
@@ -267,7 +267,7 @@ We are going to search for all employees who enjoy rock climbing:
 
 [source,js]
 --------------------------------------------------
-GET /megacorp/employee/_search
+POST /megacorp/employee/_search
 {
     "query" : {
         "match" : {
@@ -344,7 +344,7 @@ To do this, we use a slight variation of the `match` query called the
 
 [source,js]
 --------------------------------------------------
-GET /megacorp/employee/_search
+POST /megacorp/employee/_search
 {
     "query" : {
         "match_phrase" : {
@@ -392,7 +392,7 @@ Let's rerun our previous query, but add a new `highlight` parameter:
 
 [source,js]
 --------------------------------------------------
-GET /megacorp/employee/_search
+POST /megacorp/employee/_search
 {
     "query" : {
         "match_phrase" : {


### PR DESCRIPTION
When a query DSL body is present the HTTP verb cannot be GET.