### PR TITLE
Correct specify snapshot indices snippet

### DIFF
--- a/520_Post_Deployment/50_backup.asciidoc
+++ b/520_Post_Deployment/50_backup.asciidoc
@@ -125,7 +125,7 @@ In that case, you can specify which indices to back up when snapshotting your cl
 ----
 PUT _snapshot/my_backup/snapshot_2
 {
-    "indices": "index_1,index_2"
+    "indices": ["index_1","index_2"]
 }
 ----
 


### PR DESCRIPTION
It seems the indices field for snapshotting is expecting a list, not a string.