### PR TITLE
index.translog.flush_threshold_size default value

### DIFF
--- a/520_Post_Deployment/30_indexing_perf.asciidoc
+++ b/520_Post_Deployment/30_indexing_perf.asciidoc
@@ -151,7 +151,7 @@ For SSDs, you can ignore this setting.  The default is
 for SSD.
 
 Finally, you can increase `index.translog.flush_threshold_size` from the default
-200 MB to something larger, such as 1 GB.  This allows larger segments to accumulate
+512 MB to something larger, such as 1 GB.  This allows larger segments to accumulate
 in the translog before a flush occurs.  By letting larger segments build, you
 flush less often, and the larger segments merge less often.  All of this adds up
 to less disk I/O overhead and better indexing rates.


### PR DESCRIPTION
Based on the official documentation, the default value is 512mb.
https://www.elastic.co/guide/en/elasticsearch/reference/1.6/index-modules-translog.html