### PR TITLE
Update 50_Complex_datatypes.asciidoc

### DIFF
--- a/052_Mapping_Analysis/50_Complex_datatypes.asciidoc
+++ b/052_Mapping_Analysis/50_Complex_datatypes.asciidoc
@@ -45,7 +45,7 @@ values. In fact, there is no way of storing a `null` value in Lucene, so
 a field with a `null` value is also considered to be an empty
 field.((("null values", "empty fields as")))
 
-These four fields would all be considered to be empty, and would not be
+These three fields would all be considered to be empty, and would not be
 indexed:
 
 [source,js]


### PR DESCRIPTION
Under Empty Fields sub heading, the example contains three fields but in the documentation four is written. This pull request corrects that.