### PR TITLE
Update 20_Using_stopwords.asciidoc

### DIFF
--- a/240_Stopwords/20_Using_stopwords.asciidoc
+++ b/240_Stopwords/20_Using_stopwords.asciidoc
@@ -137,8 +137,9 @@ PUT /my_index
 <1> The `my_english` analyzer is based on the `english` analyzer.
 <2> But stopwords are disabled.
 
-Finally, stopwords can also be listed in a file with one word per line.  The
-file must be present on all nodes in the cluster, and the path can be
+Finally, stopwords can also be listed in a file with one word per line. 
+Lines starting with the '#' character are considered comments (stop words can not start with a '#').
+The stopwords file must be present on all nodes in the cluster, and the path can be
 specified((("stopwords_path parameter"))) with the `stopwords_path` parameter:
 
 [source,json]


### PR DESCRIPTION
It appears the stopwords file parser allows for '#' to be comments.  I can not have stopwords that start with '#'.  (For example, we wanted a common token in our data '#xxxxx' included in the stopwords, but this wouldn't work via the file).  (so documentation would at least help.  I had to look through ES code to see why this stop word wouldn't be used)
