### PR TITLE
Fixed broken bit.ly link

### DIFF
--- a/070_Index_Mgmt/20_Custom_Analyzers.asciidoc
+++ b/070_Index_Mgmt/20_Custom_Analyzers.asciidoc
@@ -48,7 +48,7 @@ After tokenization, the resulting _token stream_ is passed through any
 specified token filters,((("token filters"))) in the order in which they are specified.
 
 Token filters may change, add, or remove tokens.  We have already mentioned the
-http://bit.ly/1DIeXvZ[`lowercase`] and
+http://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-lowercase-tokenizer.html[`lowercase`] and
 http://bit.ly/1INX4tN[`stop` token filters],
 but there are many more available in Elasticsearch.
 http://bit.ly/1AUfpDN[Stemming token filters]
@@ -206,5 +206,3 @@ PUT /my_index/_mapping/my_type
 }
 --------------------------------------------------
 // SENSE: 070_Index_Mgmt/20_Custom_analyzer.json
-
-

--- a/230_Stemming/30_Hunspell_stemmer.asciidoc
+++ b/230_Stemming/30_Hunspell_stemmer.asciidoc
@@ -13,7 +13,7 @@ Hunspell dictionaries((("Hunspell stemmer", "obtaining a Hunspell dictionary")))
   unzip the `.oxt` extension file.
 * http://mzl.la/157UORf[_addons.mozilla.org_]:
   Download and unzip the `.xpi` addon file.
-* http://bit.ly/1ygnODR[OpenOffice archive]: Download and unzip the `.zip` file.
+* http://download.services.openoffice.org/contrib/dictionaries/[OpenOffice archive]: Download and unzip the `.zip` file.
 
 A Hunspell dictionary consists of two files with the same base name--such as
 `en_US`&#x2014;but with one of two extensions:

--- a/230_Stemming/60_Stemming_in_situ.asciidoc
+++ b/230_Stemming/60_Stemming_in_situ.asciidoc
@@ -19,7 +19,7 @@ Pos 4: (jumped,jump) <1>
 WARNING: Read <<stemming-in-situ-good-idea>> before using this approach.
 
 To achieve stemming _in situ_, we will use the
-http://bit.ly/1ynIBCe[`keyword_repeat`]
+http://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-keyword-repeat-tokenfilter.html[`keyword_repeat`]
 token filter,((("keyword_repeat token filter"))) which, like the `keyword_marker` token filter (see
 <<preventing-stemming>>), marks each term as a keyword to prevent the subsequent
 stemmer from touching it.  However, it also repeats the term in the same

--- a/240_Stopwords/50_Phrase_queries.asciidoc
+++ b/240_Stopwords/50_Phrase_queries.asciidoc
@@ -98,7 +98,7 @@ in the index for each field.((("fields", "index options")))  Valid values are as
 
     Store `docs`, `freqs`, `positions`, and the start and end character offsets
     of each term in the original string.  This information is used by the
-    http://bit.ly/1u9PJ16[`postings` highlighter]
+    http://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-highlighting.html#postings-highlighter[`postings` highlighter]
     but is disabled by default.
 
 You can set `index_options` on fields added at index creation time, or when
@@ -139,9 +139,3 @@ the two phrases _Man in the moon_ and _Man on the moon_.
 
 Fortunately, there is a way to have our cake and eat it: the
 <<common-grams,`common_grams` token filter>>.
-
-
-
-
-
-

--- a/300_Aggregations/100_circuit_breaker_fd_settings.asciidoc
+++ b/300_Aggregations/100_circuit_breaker_fd_settings.asciidoc
@@ -130,7 +130,7 @@ indicate a serious resource issue and a reason for poor performance.
 
 Fielddata usage can be monitored:
 
-* per-index using the http://bit.ly/1BwZ61b[`indices-stats` API]:
+* per-index using the http://www.elastic.co/guide/en/elasticsearch/reference/current/indices-stats.html[`indices-stats` API]:
 +
 [source,json]
 -------------------------------
@@ -244,6 +244,3 @@ full but is actually just garbage waiting to be collected, which is hard to
 estimate properly). But as the end user, this means the setting needs to be
 conservative, since it is comparing against total heap, not _free_ heap.
 ((("memory usage", "limiting for aggregations", startref ="ix_memagg")))
-
-
-

--- a/300_Aggregations/60_cardinality.asciidoc
+++ b/300_Aggregations/60_cardinality.asciidoc
@@ -77,7 +77,7 @@ GET /cars/transactions/_search?search_type=count
 
 ==== Understanding the Trade-offs
 As mentioned at the top of this chapter, the `cardinality` metric is an approximate
-algorithm. ((("cardinality", "understanding the tradeoffs"))) It is based on the http://bit.ly/1u6UWwd[HyperLogLog++] (HLL) algorithm.((("HLL (HyperLogLog) algorithm")))((("HyperLogLog (HLL) algorithm")))  HLL works by
+algorithm. ((("cardinality", "understanding the tradeoffs"))) It is based on the http://algo.inria.fr/flajolet/Publications/FlFuGaMe07.pdf[HyperLogLog++] (HLL) algorithm.((("HLL (HyperLogLog) algorithm")))((("HyperLogLog (HLL) algorithm")))  HLL works by
 hashing your input and using the bits from the hash to make probabilistic estimations
 on the cardinality.
 

--- a/404_Parent_Child/60_Children_agg.asciidoc
+++ b/404_Parent_Child/60_Children_agg.asciidoc
@@ -2,7 +2,7 @@
 === Children Aggregation
 
 Parent-child supports a
-http://bit.ly/1xtpjaz[`children` aggregation]  as ((("aggregations", "children aggregation")))((("children aggregation")))((("parent-child relationship", "children aggregation")))a direct analog to the `nested` aggregation discussed in
+http://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-children-aggregation.html[`children` aggregation]  as ((("aggregations", "children aggregation")))((("children aggregation")))((("parent-child relationship", "children aggregation")))a direct analog to the `nested` aggregation discussed in
 <<nested-aggregation>>.  A parent aggregation (the equivalent of
 `reverse_nested`) is not supported.
 
@@ -40,4 +40,3 @@ GET /company/branch/_search?search_type=count
 <2> The `children` aggregation joins the parent documents with
     their associated children of type `employee`.
 <3> The `hobby` field from the `employee` child documents.
-


### PR DESCRIPTION
Title says it all.  The bit.ly link no longer pointed to the correct page.  In general, there seem to be some inconsistencies in some of the bit.ly links which may need review...