### PR TITLE
Specify exactly how to submit the scroll_id query parameter.

### DIFF
--- a/060_Distributed_Search/20_Scan_and_scroll.asciidoc
+++ b/060_Distributed_Search/20_Scan_and_scroll.asciidoc
@@ -49,7 +49,7 @@ results:
 [source,js]
 --------------------------------------------------
 GET /_search/scroll?scroll=1m <1>
-c2Nhbjs1OzExODpRNV9aY1VyUVM4U0NMd2pjWlJ3YWlBOzExOTpRNV9aY1VyUVM4U0 <2>
+&scroll_id=c2Nhbjs1OzExODpRNV9aY1VyUVM4U0NMd2pjWlJ3YWlBOzExOTpRNV9aY1VyUVM4U0 <2>
 NMd2pjWlJ3YWlBOzExNjpRNV9aY1VyUVM4U0NMd2pjWlJ3YWlBOzExNzpRNV9aY1Vy
 UVM4U0NMd2pjWlJ3YWlBOzEyMDpRNV9aY1VyUVM4U0NMd2pjWlJ3YWlBOzE7dG90YW
 xfaGl0czoxOw==


### PR DESCRIPTION
The docs are missing the details about what the name of the query parameter should be for the scroll_id parameter. This makes that explicit.