### PR TITLE
Fix marvel agent installation

### DIFF
--- a/010_Intro/10_Installing_ES.asciidoc
+++ b/010_Intro/10_Installing_ES.asciidoc
@@ -48,7 +48,8 @@ in the Elasticsearch directory:
 
 [source,sh]
 --------------------------------------------------
-./bin/plugin -i elasticsearch/marvel/latest
+./bin/plugin install license
+./bin/plugin install marvel-agent
 --------------------------------------------------
 
 Marvel can also be installed using a https://www.elastic.co/guide/en/marvel/1.3/installation.html[manual process] if you don't have internet connectivity.


### PR DESCRIPTION
The existing instructions don't work.

```bash
root@e288746fffaf:/usr/share/elasticsearch# ./bin/plugin -i elasticsearch/marvel/latest
ERROR: unknown command [-i]. Use [-h] option to list available commands
```

Used instructions from https://www.elastic.co/downloads/marvel