### PR TITLE
plugin '-i' is deprecated in favor of 'install'

### DIFF
--- a/010_Intro/10_Installing_ES.asciidoc
+++ b/010_Intro/10_Installing_ES.asciidoc
@@ -48,7 +48,7 @@ in the Elasticsearch directory:
 
 [source,sh]
 --------------------------------------------------
-./bin/plugin -i elasticsearch/marvel/latest
+./bin/plugin install elasticsearch/marvel/latest
 --------------------------------------------------
 
 Marvel can also be installed using a https://www.elastic.co/guide/en/marvel/1.3/installation.html[manual process] if you don't have internet connectivity.


### PR DESCRIPTION
-i does no longer work.

```
/usr/share/elasticsearch/bin/plugin -h 

NAME

    plugin - Manages plugins

SYNOPSIS

    plugin <command>

DESCRIPTION

    Manage plugins

COMMANDS

>   install    Install a plugin

    remove     Remove a plugin

    list       List installed plugins

NOTES

    [*] For usage help on specific commands please type "plugin <command> -h"
```