### PR TITLE
update example for testing analyzer to use text param

### DIFF
--- a/052_Mapping_Analysis/40_Analysis.asciidoc
+++ b/052_Mapping_Analysis/40_Analysis.asciidoc
@@ -159,8 +159,7 @@ parameters,  and the text to analyze in the body:
 
 [source,js]
 --------------------------------------------------
-GET /_analyze?analyzer=standard
-Text to analyze
+GET /_analyze?analyzer=standard&text=Text to analyze
 --------------------------------------------------
 // SENSE: 052_Mapping_Analysis/40_Analyze.json
 

--- a/052_Mapping_Analysis/45_Mapping.asciidoc
+++ b/052_Mapping_Analysis/45_Mapping.asciidoc
@@ -277,11 +277,9 @@ name. Compare the output of these two requests:
 
 [source,js]
 --------------------------------------------------
-GET /gb/_analyze?field=tweet
-Black-cats <1>
+GET /gb/_analyze?field=tweet&text=Black-cats <1>
 
-GET /gb/_analyze?field=tag
-Black-cats <1>
+GET /gb/_analyze?field=tag&text=Black-cats <1>
 --------------------------------------------------
 // SENSE: 052_Mapping_Analysis/45_Mapping.json
 <1> The text we want to analyze is passed in the body.


### PR DESCRIPTION
while testing the analyzer
need to pass the text as a parameter

fix the example

otherwise the error is 

{
   "error": "ElasticsearchIllegalArgumentException[text is missing]",
   "status": 400
}