### PR TITLE
Remove references to replication parameter

### DIFF
--- a/040_Distributed_CRUD/15_Create_index_delete.asciidoc
+++ b/040_Distributed_CRUD/15_Create_index_delete.asciidoc
@@ -32,23 +32,6 @@ this process, possibly increasing performance at the cost of data security.
 These options are seldom used because Elasticsearch is already fast, but they
 are explained here for the sake of completeness:
 
-`replication`::
-+
---
-The default value for ((("replication request parameter", "sync and async values")))replication is `sync`. ((("sync value, replication parameter")))This causes the primary shard to
-wait for successful responses from available replica shards before returning.
-
-If you set `replication` to `async`,((("async value, replication parameter"))) it will return success to the client
-as soon as the request has been executed on the primary shard. It will still
-forward the request to the replicas, but you will not know whether the replicas
-succeeded.
-
-This option is mentioned specifically to advise against using it.  The default
-`sync` replication allows Elasticsearch to exert back pressure on whatever
-system is feeding it with data. With `async` replication, it is possible to
-overload Elasticsearch by sending too many requests without waiting for their
-completion.
-
 --
 
 `consistency`::

--- a/040_Distributed_CRUD/30_Bulk_requests.asciidoc
+++ b/040_Distributed_CRUD/30_Bulk_requests.asciidoc
@@ -47,8 +47,6 @@ The sequence of steps((("bulk API", "multiple document changes with")))((("docum
    the coordinating node, which collates the responses and returns them to the
    client.
 
-The `bulk` API also accepts((("replication request parameter", "in bulk requests")))((("consistency request parameter", "in bulk requests"))) the `replication` and `consistency` parameters
+The `bulk` API also ((("consistency request parameter", "in bulk requests"))) the `consistency` parameter
 at the top level for the whole `bulk` request, and the `routing` parameter
 in the metadata for each request.
-
-


### PR DESCRIPTION
`replication` parameter removed entirely in 2.x: https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking_20_crud_and_routing_changes.html#_async_replication