### PR TITLE
Fix broken query for Elasticseach 2.2

### DIFF
--- a/054_Query_DSL/60_Query_DSL.asciidoc
+++ b/054_Query_DSL/60_Query_DSL.asciidoc
@@ -135,7 +135,7 @@ and not marked as spam:
                 "must_not":  { "match": { "spam": true }}
             }}
         ],
-        "minimum_number_should_match": 1
+        "minimum_should_match": 1
     }
 }
 --------------------------------------------------

--- a/054_Query_DSL/60_Query_DSL.asciidoc
+++ b/054_Query_DSL/60_Query_DSL.asciidoc
@@ -126,17 +126,18 @@ and not marked as spam:
 [source,js]
 --------------------------------------------------
 {
-    "bool": {
-        "must": { "match":      { "email": "business opportunity" }},
-        "should": [
-             { "match":         { "starred": true }},
-             { "bool": {
-                   "must":      { "folder": "inbox" }},
-                   "must_not":  { "spam": true }}
-             }}
-        ],
-        "minimum_should_match": 1
-    }
+  "bool": {
+    "must": { "match": { "email": "business opportunity" } },
+    "should": [
+      { "match": { "starred": true } },
+      { "bool" : {
+          "must"     : { "match" : { "folder" : "inbox" } },
+          "must_not" : { "match" : { "spam" : true } }
+        }
+      }
+    ],
+    "minimum_number_should_match": 1
+  }
 }
 --------------------------------------------------
 

--- a/054_Query_DSL/60_Query_DSL.asciidoc
+++ b/054_Query_DSL/60_Query_DSL.asciidoc
@@ -126,18 +126,17 @@ and not marked as spam:
 [source,js]
 --------------------------------------------------
 {
-  "bool": {
-    "must": { "match": { "email": "business opportunity" } },
-    "should": [
-      { "match": { "starred": true } },
-      { "bool" : {
-          "must"     : { "match" : { "folder" : "inbox" } },
-          "must_not" : { "match" : { "spam" : true } }
-        }
-      }
-    ],
-    "minimum_number_should_match": 1
-  }
+    "bool": {
+        "must": { "match":   { "email": "business opportunity" }},
+        "should": [
+            { "match":       { "starred": true }},
+            { "bool": {
+                "must":      { "match": { "folder": "inbox" }},
+                "must_not":  { "match": { "spam": true }}
+            }}
+        ],
+        "minimum_number_should_match": 1
+    }
 }
 --------------------------------------------------
 


### PR DESCRIPTION
The sample query provided has a few issues that result in errors if someone tries to copy/paste and use it as a query clause. 

On the inner "bool" clause, " the "must" and "must_not" clauses were both missing an inner "match" parameter. 

Lastly, "minimum_should_match" is no longer correct syntax, and should be replaced by "minimum_number_should_match".