### PR TITLE
Update 26_Concurrency_solutions.asciidoc

### DIFF
--- a/400_Relationships/26_Concurrency_solutions.asciidoc
+++ b/400_Relationships/26_Concurrency_solutions.asciidoc
@@ -12,7 +12,7 @@ One of two things will happen:
 
 *   You have decided to use `version` numbers, in which case your mass rename
     will fail with a version conflict when it hits the renamed
-    `README.asciidoc` file.
+    `README.txt` file.
 
 *   You didn't use versioning, and your changes will overwrite the changes from
     the other user.


### PR DESCRIPTION
Fixes "README.asciidoc" in text to match rest of text as "README.txt"