### PR TITLE
Fixed error in Using Our Own ID section

### DIFF
--- a/030_Data/10_Index.asciidoc
+++ b/030_Data/10_Index.asciidoc
@@ -52,7 +52,7 @@ Elasticsearch responds as follows:
 --------------------------------------------------
 
 
-The response indicates that the indexing request has been successfully created
+The response indicates that the document has been successfully created
 and includes the `_index`, `_type`, and `_id` metadata, and a new element:
 `_version`.((("version number (documents)")))
 


### PR DESCRIPTION
Changed "The response indicates that the indexing request has been successfully created" to "The response indicates that the indexing request has been successfully executed" 