### PR TITLE
Changed response for 409 conflict message for 2.x

### DIFF
--- a/030_Data/40_Version_control.asciidoc
+++ b/030_Data/40_Version_control.asciidoc
@@ -154,9 +154,21 @@ code, and a body like the following:
 [source,js]
 --------------------------------------------------
 {
-  "error" : "VersionConflictEngineException[[website][2] [blog][1]:
-             version conflict, current [2], provided [1]]",
-  "status" : 409
+   "error": {
+      "root_cause": [
+         {
+            "type": "version_conflict_engine_exception",
+            "reason": "[blog][1]: version conflict, current [2], provided [1]",
+            "index": "website",
+            "shard": "3"
+         }
+      ],
+      "type": "version_conflict_engine_exception",
+      "reason": "[blog][1]: version conflict, current [2], provided [1]",
+      "index": "website",
+      "shard": "3"
+   },
+   "status": 409
 }
 --------------------------------------------------
 // SENSE: 030_Data/40_Concurrency.json


### PR DESCRIPTION
The error for 409 status has changed in 2.x, made changes to reflect the response in 2.x

