### PR TITLE
Use `analyzer` in the `name` field mapping

### DIFF
--- a/130_Partial_Matching/35_Search_as_you_type.asciidoc
+++ b/130_Partial_Matching/35_Search_as_you_type.asciidoc
@@ -235,7 +235,7 @@ GET /my_index/my_type/_search
 
 <1> This overrides the `analyzer` setting on the `name` field.
 
-Alternatively, we can specify ((("search_analyzer parameter")))((("index_analyzer parameter")))the `index_analyzer` and `search_analyzer` in
+Alternatively, we can specify ((("search_analyzer parameter")))((("analyzer parameter")))the `analyzer` and `search_analyzer` in
 the mapping for the `name` field itself. Because we want to change only the
 `search_analyzer`, we can update the existing mapping without having to
 reindex our data:
@@ -249,7 +249,7 @@ PUT /my_index/my_type/_mapping
         "properties": {
             "name": {
                 "type":            "string",
-                "index_analyzer":  "autocomplete", <1>
+                "analyzer":  "autocomplete", <1>
                 "search_analyzer": "standard" <2>
             }
         }


### PR DESCRIPTION
> Thanks for the Pull Request!  We really appreciate your help and contribution!
> 
> Before you submit the PR, have you signed Contributor License Agreement: https://www.elastic.co/contributor-agreement/ ?
> **YES**
> 
> PR's (no matter how small) cannot be merged until the CLA has been signed.  
> It only needs to be signed once, however. Thanks!
> 

Using `index_analyzer` instead of `analyzer` in the `name` field mapping update raises the following error:

```
{
   "error": {
      "root_cause": [
         {
            "type": "mapper_parsing_exception",
            "reason": "analyzer on field [name] must be set when search_analyzer is set"
         }
      ],
      "type": "mapper_parsing_exception",
      "reason": "analyzer on field [name] must be set when search_analyzer is set"
   },
   "status": 400
}
```

Hence, use `analyzer` instead of `index_analyzer` to avoid this error.