### PR TITLE
Fixed typo in 30_Bulk_requests.asciidoc

### DIFF
--- a/040_Distributed_CRUD/30_Bulk_requests.asciidoc
+++ b/040_Distributed_CRUD/30_Bulk_requests.asciidoc
@@ -47,6 +47,6 @@ The sequence of steps((("bulk API", "multiple document changes with")))((("docum
    the coordinating node, which collates the responses and returns them to the
    client.
 
-The `bulk` API also ((("consistency request parameter", "in bulk requests"))) the `consistency` parameter
+The `bulk` API also accepts ((("consistency request parameter", "in bulk requests"))) the `consistency` parameter
 at the top level for the whole `bulk` request, and the `routing` parameter
 in the metadata for each request.


### PR DESCRIPTION
Fixed missing accepts in ```"The bulk API also the consistency parameter at the top level for the whole bulk request, and the routing parameter in the metadata for each request."```

