### PR TITLE
corrects syntax for testing an analyzer

### DIFF
--- a/130_Partial_Matching/35_Search_as_you_type.asciidoc
+++ b/130_Partial_Matching/35_Search_as_you_type.asciidoc
@@ -93,7 +93,9 @@ the `analyze` API:
 [source,js]
 --------------------------------------------------
 GET /my_index/_analyze?analyzer=autocomplete
-quick brown
+{
+    "text": "quick brown"
+}
 --------------------------------------------------
 // SENSE: 130_Partial_Matching/35_Search_as_you_type.json
 


### PR DESCRIPTION
TODO: the json for Sense has to be corrected as well (it says: "child \"uri\" fails because [\"uri\" must be a valid uri]"") -> will be done in a second pull request (patch-5)