### PR TITLE
corrects syntax for testing an analyzer in json for Sense

### DIFF
--- a/snippets/130_Partial_Matching/35_Search_as_you_type.json
+++ b/snippets/130_Partial_Matching/35_Search_as_you_type.json
@@ -31,7 +31,10 @@ PUT /my_index
 }
 
 # Test the autocomplete analyzer
-GET /my_index/_analyze?analyzer=autocomplete&text=quick brown
+GET /my_index/_analyze?analyzer=autocomplete
+{
+  "text": "quick brown"
+}
 
 # Map the `name` field to use the `autocomplete` analyzer
 PUT /my_index/_mapping/mytype


### PR DESCRIPTION
at the moment, you are confronted with

{
   "statusCode": 400,
   "error": "Bad Request",
   "message": "child \"uri\" fails because [\"uri\" must be a valid uri]",
   "validation": {
      "source": "query",
      "keys": [
         "uri"
      ]
   }
}

when sending the request.