### PR TITLE
Fixed query string for analyse API

### DIFF
--- a/052_Mapping_Analysis/40_Analysis.asciidoc
+++ b/052_Mapping_Analysis/40_Analysis.asciidoc
@@ -158,10 +158,9 @@ text is analyzed. Specify which analyzer to use in the query-string
 parameters,  and the text to analyze in the body:
 
 [source,js]
---------------------------------------------------
-GET /_analyze?analyzer=standard
-&text=Text to analyze
---------------------------------------------------
+----------------------------------------------------
+GET /_analyze?analyzer=standard&text=Text to analyze
+----------------------------------------------------
 // SENSE: 052_Mapping_Analysis/40_Analyze.json
 
 

--- a/052_Mapping_Analysis/40_Analysis.asciidoc
+++ b/052_Mapping_Analysis/40_Analysis.asciidoc
@@ -160,7 +160,7 @@ parameters,  and the text to analyze in the body:
 [source,js]
 --------------------------------------------------
 GET /_analyze?analyzer=standard
-Text to analyze
+&text=Text to analyze
 --------------------------------------------------
 // SENSE: 052_Mapping_Analysis/40_Analyze.json
 


### PR DESCRIPTION
json snippet (https://www.elastic.co/guide/en/elasticsearch/guide/current/snippets/052_Mapping_Analysis/40_Analyze.json) has correct command whereas in the guide the text query parameter is missing.

Proposing change to make the guide and the json snippet consistent as the GET command in the guide does not work due to missing text=Text to analyze query parameter