### PR TITLE
Correct typo in Analyzer example

### DIFF
--- a/052_Mapping_Analysis/40_Analysis.asciidoc
+++ b/052_Mapping_Analysis/40_Analysis.asciidoc
@@ -159,8 +159,7 @@ parameters,  and the text to analyze in the body:
 
 [source,js]
 --------------------------------------------------
-GET /_analyze?analyzer=standard
-Text to analyze
+GET /_analyze?analyzer=standard&text=Text to analyze
 --------------------------------------------------
 // SENSE: 052_Mapping_Analysis/40_Analyze.json
 


### PR DESCRIPTION
Correcting a small typo in the Guide.