### PR TITLE
Fixed typo in usage of analyze api

### DIFF
--- a/080_Structured_Search/05_term.asciidoc
+++ b/080_Structured_Search/05_term.asciidoc
@@ -146,10 +146,9 @@ the data has been indexed. ((("analyze API, using to understand tokenization")))
 can see that our UPC has been tokenized into smaller tokens:
 
 [source,js]
---------------------------------------------------
-GET /my_store/_analyze?field=productID
-XHDK-A-1293-#fJ3
---------------------------------------------------
+--------------------------------------------------------------
+GET /my_store/_analyze?field=productID&text=XHDK-A-1293-%23fJ3
+--------------------------------------------------------------
 [source,js]
 --------------------------------------------------
 {


### PR DESCRIPTION
JSON snippet https://www.elastic.co/guide/en/elasticsearch/guide/current/snippets/080_Structured_Search/05_Term_text.json has correct command where as the guide has typo.