### PR TITLE
Fix query object structure

### DIFF
--- a/010_Intro/30_Tutorial_Search.asciidoc
+++ b/010_Intro/30_Tutorial_Search.asciidoc
@@ -210,11 +210,11 @@ GET /megacorp/employee/_search
 {
     "query" : {
         "bool": {
-            "must": [
+            "must": {
                 "match" : {
                     "last_name" : "smith" <1>
                 }
-            ],
+            },
             "filter": {
                 "range" : {
                     "age" : { "gt" : 30 } <2>


### PR DESCRIPTION
The query object under 'More-Complicated Searches' is not a valid JSON structure. This replaces the erroneous square braces around the "must" object with curly braces.