### PR TITLE
Resolve error in "More-Complicated Searches" example

### DIFF
--- a/010_Intro/30_Tutorial_Search.asciidoc
+++ b/010_Intro/30_Tutorial_Search.asciidoc
@@ -209,15 +209,15 @@ which allows us to execute structured searches efficiently:
 GET /megacorp/employee/_search
 {
     "query" : {
-        "bool": {
-            "must": [
-                "match" : {
-                    "last_name" : "smith" <1>
-                }
-            ],
-            "filter": {
+        "filtered" : {
+            "filter" : {
                 "range" : {
-                    "age" : { "gt" : 30 } <2>
+                    "age" : { "gt" : 30 } <1>
+                }
+            },
+            "query" : {
+                "match" : {
+                    "last_name" : "smith" <2>
                 }
             }
         }
@@ -226,9 +226,9 @@ GET /megacorp/employee/_search
 --------------------------------------------------
 // SENSE: 010_Intro/30_Query_DSL.json
 
-<1> This portion of the query is the((("match queries"))) same `match` _query_ that we used before.
-<2> This portion of the query is a `range` _filter_, which((("range filters"))) will find all ages
+<1> This portion of the query is a `range` _filter_, which((("range filters"))) will find all ages
     older than 30&#x2014;`gt` stands for _greater than_.
+<2> This portion of the query is the((("match queries"))) same `match` _query_ that we used before.
 
 
 Don't worry about the syntax too much for now; we will cover it in great


### PR DESCRIPTION
The current on-page example in "More-Complicated Searches" produces an error (included below) using Elasticsearch 2.3.2.

To resolve this, moving code from SENSE example (which works) onto the page.

__Error from current on-page example:__
```javascript
{
  "error": {
    "root_cause": [
      {
        "type": "query_parsing_exception",
        "reason": "Failed to parse",
        "index": "megacorp"
      }
    ],
    "type": "search_phase_execution_exception",
    "reason": "all shards failed",
    "phase": "query_fetch",
    "grouped": true,
    "failed_shards": [
      {
        "shard": 0,
        "index": "megacorp",
        "node": "nodeIDHash",
        "reason": {
          "type": "query_parsing_exception",
          "reason": "Failed to parse",
          "index": "megacorp",
          "caused_by": {
            "type": "json_parse_exception",
            "reason": "Unexpected character (':' (code 58)): was expecting comma to separate ARRAY entries\n at [Source: [B@2cc82fb6; line: 5, column: 26]"
          }
        }
      }
    ]
  },
  "status": 400
}
```