### PR TITLE
Update 30_Tutorial_Search.asciidoc

### DIFF
--- a/010_Intro/30_Tutorial_Search.asciidoc
+++ b/010_Intro/30_Tutorial_Search.asciidoc
@@ -210,11 +210,11 @@ GET /megacorp/employee/_search
 {
     "query" : {
         "bool": {
-            "must": [
+            "must": {
                 "match" : {
                     "last_name" : "smith" <1>
                 }
-            ],
+            },
             "filter": {
                 "range" : {
                     "age" : { "gt" : 30 } <2>


### PR DESCRIPTION
"must" as an array cases "Expected ',' instead of ':'" syntax error in Sense, and running the command as-is returns a query-parsing exception.

Making it an object seems to work as expected.