### PR TITLE
Improper word choice.

### DIFF
--- a/510_Deployment/50_heap.asciidoc
+++ b/510_Deployment/50_heap.asciidoc
@@ -122,7 +122,7 @@ $ JAVA_HOME=`/usr/libexec/java_home -v 1.8` java -Xmx32767m -XX:+PrintFlagsFinal
      bool UseCompressedOops   = false
 ----
 
-The morale of the story is that the exact cutoff to leverage compressed oops
+The moral of the story is that the exact cutoff to leverage compressed oops
 varies from JVM to JVM, so take caution when taking examples from elsewhere and
 be sure to check your system with your configuration and JVM.
 


### PR DESCRIPTION
Improper use of the word "morale". Should be "moral": http://www.gingersoftware.com/english-online/spelling-book/confusing-words/moral-morale

