### PR TITLE
Add missing comma to JSON in example

### DIFF
--- a/052_Mapping_Analysis/45_Mapping.asciidoc
+++ b/052_Mapping_Analysis/45_Mapping.asciidoc
@@ -280,7 +280,7 @@ name. Compare the output of these two requests:
 --------------------------------------------------
 GET /gb/_analyze
 {
-  "field": "tweet"
+  "field": "tweet",
   "text": "Black-cats" <1>
 }
 


### PR DESCRIPTION
This is trivial, but the example as-is isn't valid JSON.

Add missing comma to example JSON so it parses correctly when copy/pasted.