### PR TITLE
Another - comma instead of dot in lat field in query example

### DIFF
--- a/330_Geo_aggs/66_Geo_bounds_agg.asciidoc
+++ b/330_Geo_aggs/66_Geo_bounds_agg.asciidoc
@@ -86,7 +86,7 @@ GET /attractions/restaurant/_search
         "geo_bounding_box": {
           "location": {
             "top_left": {
-              "lat":  40,8,
+              "lat":  40.8,
               "lon": -74.1
             },
             "bottom_right": {


### PR DESCRIPTION
<!--
Thanks for the Pull Request!  We really appreciate your help and contribution!

Before you submit the PR, have you signed Contributor License Agreement: https://www.elastic.co/contributor-agreement/ ?

PR's (no matter how small) cannot be merged until the CLA has been signed.  
It only needs to be signed once, however. Thanks!
-->

There is a mistake in query example in "lat" can't be 40,8
Fixed 40,8 -> 40.8