### PR TITLE
Deprecated "filtered" query replaced by "bool"

### DIFF
--- a/010_Intro/replace_filtered_by_bool
+++ b/010_Intro/replace_filtered_by_bool
@@ -209,15 +209,15 @@ which allows us to execute structured searches efficiently:
 GET /megacorp/employee/_search
 {
     "query" : {
-        "filtered" : {
-            "filter" : {
-                "range" : {
-                    "age" : { "gt" : 30 } <1>
+        "bool" : {
+            "must" : {
+                "match" : {
+                    "last_name" : "smith" <1>
                 }
             },
-            "query" : {
-                "match" : {
-                    "last_name" : "smith" <2>
+            "filter" : {
+                "range" : {
+                    "age" : { "gt" : 30 } <2>
                 }
             }
         }
@@ -226,9 +226,9 @@ GET /megacorp/employee/_search
 --------------------------------------------------
 // SENSE: 010_Intro/30_Query_DSL.json
 
-<1> This portion of the query is a `range` _filter_, which((("range filters"))) will find all ages
+<1> This portion of the query is the((("match queries"))) same `match` _query_ that we used before.
+<2> This portion of the query is a `range` _filter_, which((("range filters"))) will find all ages
     older than 30&#x2014;`gt` stands for _greater than_.
-<2> This portion of the query is the((("match queries"))) same `match` _query_ that we used before.
 
 
 Don't worry about the syntax too much for now; we will cover it in great


### PR DESCRIPTION
<!--
Thanks for the Pull Request!  We really appreciate your help and contribution!

Before you submit the PR, have you signed Contributor License Agreement: https://www.elastic.co/contributor-agreement/ ?

PR's (no matter how small) cannot be merged until the CLA has been signed.  
It only needs to be signed once, however. Thanks!
-->

In current example "filtered" query is used, which is deprecated since elasticsearch 2.0.0-beta1. I replaced it on proper, "bool" query.