### PR TITLE
Correct the query that would match

### DIFF
--- a/402_Nested/30_Nested_objects.asciidoc
+++ b/402_Nested/30_Nested_objects.asciidoc
@@ -47,8 +47,8 @@ GET /_search
   "query": {
     "bool": {
       "must": [
-        { "match": { "name": "Alice" }},
-        { "match": { "age":  28      }} <1>
+        { "match": { "comments.name": "Alice" }},
+        { "match": { "comments.age":  28      }} <1>
       ]
     }
   }


### PR DESCRIPTION
The query that would match the document with a `comments` field of type `object` needs fully qualified field names `comments.name` and `comments.age`.