### PR TITLE
Append '.keyword' to field

### DIFF
--- a/300_Aggregations/20_basic_example.asciidoc
+++ b/300_Aggregations/20_basic_example.asciidoc
@@ -52,7 +52,7 @@ GET /cars/transactions/_search
     "aggs" : { <1>
         "popular_colors" : { <2>
             "terms" : { <3>
-              "field" : "color"
+              "field" : "color.keyword"
             }
         }
     }
@@ -96,10 +96,12 @@ Let's execute that aggregation and take a look at the results:
 {
 ...
    "hits": {
+      ...
       "hits": [] <1>
    },
    "aggregations": {
       "popular_colors": { <2>
+         ...
          "buckets": [
             {
                "key": "red", <3>


### PR DESCRIPTION
<!--
Thanks for the Pull Request!  We really appreciate your help and contribution!

Before you submit the PR, have you signed Contributor License Agreement: https://www.elastic.co/contributor-agreement/ ?

PR's (no matter how small) cannot be merged until the CLA has been signed.  
It only needs to be signed once, however. Thanks!
-->

Same as in https://github.com/elastic/elasticsearch/pull/17942/files: it seems like you always need to append '.keyword' to the field for aggregation...

I am new to elasticsearch. For me, the error message I got without .keyword, namely
```
"reason" : "Fielddata is disabled on text fields by default. Set fielddata=true on [color] in order to load fielddata in memory by uninverting the inverted index. Note that this can however use significant memory."
```
seems to be misleading. At least, the proposed workaround to follow https://www.elastic.co/guide/en/elasticsearch/reference/current/fielddata.html#_enabling_fielddata_on_literal_text_literal_fields did not work for me. I tried 
```
curl -XPUT 'localhost:9200/cars/transactions/color?pretty' -d'
{
  "properties": {
    "my_field": {
      "type":     "text",
      "fielddata": false
    }
  }
}'
```
I was not sure on the my_type, so I tried with ```PUT 'localhost:9200/cars/transactions/popular_colors``` as well.