### PR TITLE
Adding .keyword to field, so example works with v5.0.1

### DIFF
--- a/300_Aggregations/21_add_metric.asciidoc
+++ b/300_Aggregations/21_add_metric.asciidoc
@@ -20,7 +20,7 @@ GET /cars/transactions/_search
    "aggs": {
       "colors": {
          "terms": {
-            "field": "color"
+            "field": "color.keyword"
          },
          "aggs": { <1>
             "avg_price": { <2>
@@ -53,6 +53,7 @@ and what field we want the average to be calculated on (`price`):
 ...
    "aggregations": {
       "colors": {
+         ...
          "buckets": [
             {
                "key": "red",


### PR DESCRIPTION
<!--
Thanks for the Pull Request!  We really appreciate your help and contribution!

Before you submit the PR, have you signed Contributor License Agreement: https://www.elastic.co/contributor-agreement/ ?

PR's (no matter how small) cannot be merged until the CLA has been signed.  
It only needs to be signed once, however. Thanks!
-->

Same as https://github.com/elastic/elasticsearch-definitive-guide/pull/631:

In v 5.0.1, I have found that I get following error message, if the '.keyword' is missing:
```
"reason" : "Fielddata is disabled on text fields by default. Set fielddata=true on [color] in order to load fielddata in memory by uninverting the inverted index. Note that this can however use significant memory."
```
seems to be misleading. At least, the proposed workaround to follow https://www.elastic.co/guide/en/elasticsearch/reference/current/fielddata.html#_enabling_fielddata_on_literal_text_literal_fields did not work for me. I tried 
```
With .```keyword```, it seems to work. Found via https://github.com/elastic/elasticsearch/pull/17942.