### PR TITLE
Corrected the syntax of vm.swappiness commad for linux

### DIFF
--- a/510_Deployment/50_heap.asciidoc
+++ b/510_Deployment/50_heap.asciidoc
@@ -200,7 +200,7 @@ For most Linux systems, this is configured using the `sysctl` value:
 
 [source,bash]
 ----
-vm.swappiness = 1 <1>
+vm.swappiness=1 <1>
 ----
 <1> A `swappiness` of `1` is better than `0`, since on some kernel versions a `swappiness`
 of `0` can invoke the OOM-killer.


### PR DESCRIPTION
<!--
Thanks for the Pull Request!  We really appreciate your help and contribution!

Before you submit the PR, have you signed Contributor License Agreement: https://www.elastic.co/contributor-agreement/ ?

PR's (no matter how small) cannot be merged until the CLA has been signed.  
It only needs to be signed once, however. Thanks!
-->

In linux, while changing the value of "swappiness" using sysctl, i observed that the space before and after the equals sign "=" was resulting in the below malformed error :

```
root@xx-yy:/home/abc# sysctl vm.swappiness = 1
vm.swappiness = 60
sysctl: malformed setting "="
sysctl: cannot stat /proc/sys/1: No such file or directory
```

Hence I have removed the space and now the command (vm.swappiness=1) can be copied and executed avoiding the malformed exception.