### PR TITLE
Added info about precedence between transient and persistent settings.

### DIFF
--- a/520_Post_Deployment/10_dynamic_settings.asciidoc
+++ b/520_Post_Deployment/10_dynamic_settings.asciidoc
@@ -10,11 +10,13 @@ The `cluster-update` API operates((("Cluster Update API"))) in two modes:
 
 Transient:: 
     These changes are in effect until the cluster restarts.  Once
-a full cluster restart takes place, these settings are erased.
+a full cluster restart takes place, these settings are erased. They override
+persistent settings and settings in the static configuration files.
 
 Persistent::
     These changes are permanently in place unless explicitly changed.
-They will survive full cluster restarts and override the static configuration files.
+They will survive full cluster restarts. They override the static configuration files
+and can be overridden by transient settings.
 
 Transient versus persistent settings are supplied in the JSON body:
 


### PR DESCRIPTION
I was confused about the interaction between transient and persistent settings. [This page](https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-update-settings.html#_precedence_of_settings) in the docs cleared it up, so I'm adding that information here.