### PR TITLE
Correct idf(t) formula as used in Lucene source

### DIFF
--- a/170_Relevance/10_Scoring_theory.asciidoc
+++ b/170_Relevance/10_Scoring_theory.asciidoc
@@ -96,11 +96,11 @@ like `elastic` or `hippopotamus` help us zoom in on the most interesting
 documents. The inverse document frequency is calculated as follows:
 
 ..........................
-idf(t) = 1 + log ( numDocs / (docFreq + 1)) <1>
+idf(t) = 1 + log ( (docCount + 1) / (docFreq + 1)) <1>
 ..........................
 <1> The inverse document frequency (`idf`) of term `t` is the
-    logarithm of the number of documents in the index, divided by
-    the number of documents that contain the term.
+    logarithm of the number of documents in the index (`docCount`) plus 1, divided by
+    the number of documents that contain the term (`docFreq`) + 1.
 
 
 [[field-norm]]


### PR DESCRIPTION
From the ClassicSimilarity class in Lucene 6 source code, we have the following:

public float idf(long docFreq, long docCount) {
    return (float)(Math.log((docCount+1)/(double)(docFreq+1)) + 1.0);
  }

<!--
Thanks for the Pull Request!  We really appreciate your help and contribution!

Before you submit the PR, have you signed Contributor License Agreement: https://www.elastic.co/contributor-agreement/ ?

PR's (no matter how small) cannot be merged until the CLA has been signed.  
It only needs to be signed once, however. Thanks!
-->
