### PR TITLE
Update 35_Tutorial_Aggregations.asciidoc

### DIFF
--- a/010_Intro/35_Tutorial_Aggregations.asciidoc
+++ b/010_Intro/35_Tutorial_Aggregations.asciidoc
@@ -13,7 +13,7 @@ GET /megacorp/employee/_search
 {
   "aggs": {
     "all_interests": {
-      "terms": { "field": "interests" }
+      "terms": { "field": "interests.keyword" }
     }
   }
 }
@@ -66,7 +66,7 @@ GET /megacorp/employee/_search
   "aggs": {
     "all_interests": {
       "terms": {
-        "field": "interests"
+        "field": "interests.keyword"
       }
     }
   }
@@ -102,7 +102,7 @@ GET /megacorp/employee/_search
 {
     "aggs" : {
         "all_interests" : {
-            "terms" : { "field" : "interests" },
+            "terms" : { "field" : "interests.keyword" },
             "aggs" : {
                 "avg_age" : {
                     "avg" : { "field" : "age" }


### PR DESCRIPTION
The example queries result in this error:

    Fielddata is disabled on text fields by default. Set fielddata=true on [interests] in order to load fielddata in memory by uninverting the inverted index. Note that this can however use significant memory.

Don't really understand what's going on yet as this is my first day with ES, but I found using `"field": "interests.keyword"` instead of `"field": "interests"` gives the desired result. It'd be good if an easy to understand explanation for the need of this `.keyword` was provided too (people at this page are mostly beginners).

<!--
Thanks for the Pull Request!  We really appreciate your help and contribution!

Before you submit the PR, have you signed Contributor License Agreement: https://www.elastic.co/contributor-agreement/ ?

PR's (no matter how small) cannot be merged until the CLA has been signed.  
It only needs to be signed once, however. Thanks!
-->
