### PR TITLE
Update 75_sigterms.asciidoc

### DIFF
--- a/300_Aggregations/75_sigterms.asciidoc
+++ b/300_Aggregations/75_sigterms.asciidoc
@@ -262,12 +262,10 @@ with a simple filtered query:
 ----
 GET mlmovies/_search
 {
-  "query": {
-    "filtered": {
-      "filter": {
-        "ids": {
-          "values": [2571,318,296,2959,260]
-        }
+  "bool": {
+    "filter": {
+      "ids": {
+        "values": [2571,318,296,2959,260]
       }
     }
   }


### PR DESCRIPTION
The filtered query has been deprecated and removed in ES 5.0. You should now use the bool/must/filter query instead.

<!--
Thanks for the Pull Request!  We really appreciate your help and contribution!

Before you submit the PR, have you signed Contributor License Agreement: https://www.elastic.co/contributor-agreement/ ?

PR's (no matter how small) cannot be merged until the CLA has been signed.  
It only needs to be signed once, however. Thanks!
-->
