### PR TITLE
Update 75_sigterms.asciidoc

### DIFF
--- a/300_Aggregations/75_sigterms.asciidoc
+++ b/300_Aggregations/75_sigterms.asciidoc
@@ -262,12 +262,10 @@ with a simple filtered query:
 ----
 GET mlmovies/_search
 {
-  "query": {
-    "filtered": {
-      "filter": {
-        "ids": {
-          "values": [2571,318,296,2959,260]
-        }
+  "bool": {
+    "filter": {
+      "ids": {
+        "values": [2571,318,296,2959,260]
       }
     }
   }


### PR DESCRIPTION
The filtered query has been deprecated and removed in ES 5.0. You should now use the bool/must/filter query instead.