### PR TITLE
Formatting fixes for the Cluster Administration chapter

### DIFF
--- a/500_Cluster_Admin/10_intro.asciidoc
+++ b/500_Cluster_Admin/10_intro.asciidoc
@@ -1,15 +1,16 @@
 
-Elasticsearch is often deployed as a cluster of nodes.((("clusters", "administration")))  A variety of
-APIs let you manage and monitor the cluster itself, rather than interact
-with the data stored within the cluster.
+Elasticsearch is often deployed as a cluster of nodes. A variety of APIs let you
+manage and monitor the cluster itself, rather than interact with the data stored
+within the cluster.
 
 As with most functionality in Elasticsearch, there is an overarching design goal
 that tasks should be performed through an API rather than by modifying static
-configuration files.  This becomes especially important as your cluster scales.
-Even with a provisioning system (such as Puppet, Chef, and Ansible), a single HTTP API call
-is often simpler than pushing new configurations to hundreds of physical machines.
+configuration files. This becomes especially important as your cluster scales.
+Even with a provisioning system (such as Puppet, Chef, and Ansible), a single
+HTTP API call is often simpler than pushing new configurations to hundreds of
+physical machines.
 
 To that end, this chapter presents the various APIs that allow you to
-dynamically tweak, tune, and configure your cluster.  It also covers a
-host of APIs that provide statistics about the cluster itself so you can
-monitor for health and performance.
+dynamically tweak, tune, and configure your cluster. It also covers a host of
+APIs that provide statistics about the cluster itself so you can monitor for
+health and performance.

--- a/500_Cluster_Admin/20_health.asciidoc
+++ b/500_Cluster_Admin/20_health.asciidoc
@@ -1,13 +1,14 @@
 
 === Cluster Health
 
-An Elasticsearch cluster may consist of a single node with a single index.  Or it((("cluster health")))((("clusters", "administration", "Cluster Health API")))
-may have a hundred data nodes, three dedicated masters, a few dozen client nodes--all operating on a thousand indices (and tens of thousands of shards).
+An Elasticsearch cluster may consist of a single node with a single index. Or it
+may have a hundred data nodes, three dedicated masters, a few dozen client
+nodes--all operating on a thousand indices (and tens of thousands of shards).
 
 No matter the scale of the cluster, you'll want a quick way to assess the status
-of your cluster.  The `Cluster Health` API fills that role.  You can think of it
-as a 10,000-foot view of your cluster.  It can reassure you that everything
-is all right, or alert you to a problem somewhere in your cluster.
+of your cluster. The `Cluster Health` API fills that role. You can think of it
+as a 10,000-foot view of your cluster. It can reassure you that everything is
+all right, or alert you to a problem somewhere in your cluster.
 
 Let's execute a `cluster-health` API and see what the response looks like:
 
@@ -45,7 +46,7 @@ operational.
 
 `yellow`::
     All primary shards are allocated, but at least one replica is missing.
-No data is missing, so search results will still be complete. However,  your 
+No data is missing, so search results will still be complete. However,  your
 high availability is compromised to some degree.  If _more_ shards disappear, you
 might lose data.  Think of `yellow` as a warning that should prompt investigation.
 
@@ -66,10 +67,10 @@ includes replica shards.
 one node to another node.  This number is often zero, but can increase when
 Elasticsearch decides a cluster is not properly balanced, a new node is added,
 or a node is taken down, for example.
-- `initializing_shards` is a count of shards that are being freshly created. For 
+- `initializing_shards` is a count of shards that are being freshly created. For
 example, when you first create an index, the shards will all briefly reside in
 `initializing` state.  This is typically a transient event, and shards shouldn't
-linger in `initializing` too long.  You may also see initializing shards when a 
+linger in `initializing` too long.  You may also see initializing shards when a
 node is first restarted: as shards are loaded from disk, they start as `initializing`.
 - `unassigned_shards` are shards that exist in the cluster state, but cannot be
 found in the cluster itself.  A common source of unassigned shards are unassigned
@@ -79,7 +80,7 @@ cluster is `red` (since primaries are missing).
 
 ==== Drilling Deeper: Finding Problematic Indices
 
-Imagine something goes wrong one day,((("indices", "problematic, finding"))) and you notice that your cluster health
+Imagine something goes wrong one day, and you notice that your cluster health
 looks like this:
 
 [source,js]
@@ -98,15 +99,15 @@ looks like this:
 }
 ----
 
-OK, so what can we deduce from this health status?  Well, our cluster is `red`,
-which means we are missing data (primary + replicas).  We know our cluster has
-10 nodes, but see only 8 data nodes listed in the health.  Two of our nodes
-have gone missing.  We see that there are 20 unassigned shards.  
+OK, so what can we deduce from this health status? Well, our cluster is `red`,
+which means we are missing data (primary + replicas). We know our cluster has 10
+nodes, but see only 8 data nodes listed in the health. Two of our nodes have
+gone missing. We see that there are 20 unassigned shards.
 
 That's about all the information we can glean.  The nature of those missing
 shards are still a mystery.  Are we missing 20 indices with 1 primary shard each?
 Or 1 index with 20 primary shards? Or 10 indices with 1 primary + 1 replica?
-Which index? 
+Which index?
 
 To answer these questions, we need to ask `cluster-health` for a little more
 information by using the `level` parameter:
@@ -183,40 +184,43 @@ The `level` parameter accepts one more option:
 GET _cluster/health?level=shards
 ----
 
-The `shards` option will provide a very verbose output, which lists the status 
+The `shards` option will provide a very verbose output, which lists the status
 and location of every shard inside every index.  This output is sometimes useful,
 but because of the verbosity can be difficult to work with.  Once you know the index
-that is having problems, other APIs that we discuss in this chapter will tend 
+that is having problems, other APIs that we discuss in this chapter will tend
 to be more helpful.
 
 ==== Blocking for Status Changes
 
 The `cluster-health` API has another neat trick that is useful when building
 unit and integration tests, or automated scripts that work with Elasticsearch.
-You can specify a `wait_for_status` parameter, which will only return after the status is satisfied.  For example:
+You can specify a `wait_for_status` parameter, which will only return after the
+status is satisfied. For example:
 
 [source,bash]
 ----
 GET _cluster/health?wait_for_status=green
 ----
 
-This call will _block_ (not return control to your program) until the `cluster-health` has turned `green`, meaning all primary and replica shards have been allocated.
-This is important for automated scripts and tests.
+This call will _block_ (not return control to your program) until the
+`cluster-health` has turned `green`, meaning all primary and replica shards have
+been allocated. This is important for automated scripts and tests.
 
 If you create an index, Elasticsearch must broadcast the change in cluster state
-to all nodes.  Those nodes must initialize those new shards, and then respond to the
-master that the shards are `Started`.  This process is fast, but because of network
-latency may take 10&#x2013;20ms.
+to all nodes. Those nodes must initialize those new shards, and then respond to
+the master that the shards are `Started`. This process is fast, but because of
+network latency may take 10&#x2013;20ms.
 
-If you have an automated script that (a) creates an index and then (b) immediately
-attempts to index a document, this operation may fail, because the index has not
-been fully initialized yet.  The time between (a) and (b) will likely be less than 1ms--not nearly enough time to account for network latency.
+If you have an automated script that (a) creates an index and then (b)
+immediately attempts to index a document, this operation may fail, because the
+index has not been fully initialized yet. The time between (a) and (b) will
+likely be less than 1ms--not nearly enough time to account for network latency.
 
-Rather than sleeping, just have your script/test call `cluster-health` with
-a `wait_for_status` parameter.  As soon as the index is fully created, the `cluster-health` will change to `green`, the call will return control to your script, and you may
-begin indexing.
+Rather than sleeping, just have your script/test call `cluster-health` with a
+`wait_for_status` parameter. As soon as the index is fully created, the
+`cluster-health` will change to `green`, the call will return control to your
+script, and you may begin indexing.
 
-Valid options are `green`, `yellow`, and `red`.  The call will return when the 
-requested status (or one "higher") is reached. For example, if you request `yellow`,
-a status change to `yellow` or `green` will unblock the call.
-
+Valid options are `green`, `yellow`, and `red`. The call will return when the
+requested status (or one "higher") is reached. For example, if you request
+`yellow`, a status change to `yellow` or `green` will unblock the call.

--- a/500_Cluster_Admin/30_node_stats.asciidoc
+++ b/500_Cluster_Admin/30_node_stats.asciidoc
@@ -2,14 +2,14 @@
 === Monitoring Individual Nodes
 
 `Cluster-health` is at one end of the spectrum--a very high-level overview of
-everything in your cluster. ((("clusters", "administration", "monitoring individual nodes")))((("nodes", "monitoring individual nodes"))) The `node-stats` API is at the other end. ((("Node Stats API", id="ix_NodeStats", range="startofrange"))) It provides
-a bewildering array of statistics about each node in your cluster.
+everything in your cluster. The `node-stats` API is at the other end. It
+provides a bewildering array of statistics about each node in your cluster.
 
-`Node-stats` provides so many stats that, until you are accustomed to the output,
-you may be unsure which metrics are most important to keep an eye on.  We'll
-highlight the most important metrics to monitor (but we encourage you to
-log all the metrics provided--or use Marvel--because you'll never know when
-you need one stat or another).
+`Node-stats` provides so many stats that, until you are accustomed to the
+output, you may be unsure which metrics are most important to keep an eye on.
+We'll highlight the most important metrics to monitor (but we encourage you to
+log all the metrics provided--or use Marvel--because you'll never know when you
+need one stat or another.)
 
 The `node-stats` API can be executed with the following:
 
@@ -37,15 +37,15 @@ Starting at the top of the output, we see the cluster name and our first node:
 ...
 ----
 
-The nodes are listed in a hash, with the key being the UUID of the node.  Some
-information about the node's network properties are displayed (such as transport address,
-and host). These values are useful for debugging discovery problems, where
-nodes won't join the cluster. Often you'll see that the port being used is wrong,
-or the node is binding to the wrong IP address/interface.
+The nodes are listed in a hash, with the key being the UUID of the node. Some
+information about the node's network properties are displayed (such as transport
+address, and host). These values are useful for debugging discovery problems,
+where nodes won't join the cluster. Often you'll see that the port being used is
+wrong, or the node is binding to the wrong IP address/interface.
 
 ==== indices Section
 
-The `indices` section lists aggregate statistics((("indices", "indices section in Node Stats API"))) for all the indices that reside
+The `indices` section lists aggregate statistics for all the indices that reside
 on this particular node:
 
 [source,js]
@@ -63,13 +63,12 @@ on this particular node:
 
 The returned statistics are grouped into the following sections:
 
-- `docs` shows how many documents reside on
-this node, as well as the number of deleted docs that haven't been purged
-from segments yet.
+- `docs` shows how many documents reside on this node, as well as the number of
+deleted docs that haven't been purged from segments yet.
 
-- The `store` portion indicates how much physical storage is consumed by the node.
-This metric includes both primary and replica shards.  If the throttle time is
-large, it may be an indicator that your disk throttling is set too low
+- The `store` portion indicates how much physical storage is consumed by the
+node. This metric includes both primary and replica shards. If the throttle time
+is large, it may be an indicator that your disk throttling is set too low
 (discussed in <<segments-and-merging>>).
 
 [source,js]
@@ -111,35 +110,37 @@ large, it may be an indicator that your disk throttling is set too low
         },
 ----
 
-- `indexing` shows the number of docs that have been indexed.  This value is a monotonically
-increasing counter; it doesn't decrease when docs are deleted.  Also note that it
-is incremented anytime an _index_ operation happens internally, which includes
-things like updates.
+- `indexing` shows the number of docs that have been indexed. This value is a
+monotonically increasing counter; it doesn't decrease when docs are deleted.
+Also note that it is incremented anytime an _index_ operation happens
+internally, which includes things like updates.
 +
 Also listed are times for indexing, the number of docs currently being indexed,
 and similar statistics for deletes.
 
-- `get` shows statistics about get-by-ID statistics.  This includes `GET` and
+- `get` shows statistics about get-by-ID statistics. This includes `GET` and
 `HEAD` requests for a single document.
 
 - `search` describes the number of active searches (`open_contexts`), number of
 queries total, and the amount of time spent on queries since the node was
-started.  The ratio between `query_time_in_millis / query_total` can be used as a
-rough indicator for how efficient your queries are.  The larger the ratio,
-the more time each query is taking, and you should consider tuning or optimization.
+started. The ratio between `query_time_in_millis / query_total` can be used as a
+rough indicator for how efficient your queries are. The larger the ratio, the
+more time each query is taking, and you should consider tuning or optimization.
 +
 The fetch statistics detail the second half of the query process (the _fetch_ in
-query-then-fetch).  If more time is spent in fetch than query, this can be an
-indicator of slow disks or very large documents being fetched, or
-potentially search requests with paginations that are too large (for example, `size: 10000`).
+query-then-fetch). If more time is spent in fetch than query, this can be an
+indicator of slow disks or very large documents being fetched, or potentially
+search requests with paginations that are too large (for example, `size:
+10000`).
 
-- `merges` contains information about Lucene segment merges.  It will tell you
-the number of merges that are currently active, the number of docs involved, the cumulative
-size of segments being merged, and the amount of time spent on merges in total.
+- `merges` contains information about Lucene segment merges. It will tell you
+the number of merges that are currently active, the number of docs involved, the
+cumulative size of segments being merged, and the amount of time spent on merges
+in total.
 +
-Merge statistics can be important if your cluster is write heavy.  Merging consumes
-a large amount of disk I/O and CPU resources.  If your index is write heavy and
-you see large merge numbers, be sure to read <<indexing-performance>>.
+Merge statistics can be important if your cluster is write heavy. Merging
+consumes a large amount of disk I/O and CPU resources. If your index is write
+heavy and you see large merge numbers, be sure to read <<indexing-performance>>.
 +
 Note: updates and deletes will contribute to large merge numbers too, since they
 cause segment _fragmentation_ that needs to be merged out eventually.
@@ -161,50 +162,53 @@ cause segment _fragmentation_ that needs to be merged out eventually.
         ...
 ----
 
-- `filter_cache` indicates the amount of memory used by the cached filter bitsets,
-and the number of times a filter has been evicted.  A large number of evictions
-_could_ indicate that you need to increase the filter cache size, or that
-your filters are not caching well (for example, they are churning heavily because of high cardinality,
-such as caching `now` date expressions).
+- `filter_cache` indicates the amount of memory used by the cached filter
+bitsets, and the number of times a filter has been evicted. A large number of
+evictions _could_ indicate that you need to increase the filter cache size, or
+that your filters are not caching well (for example, they are churning heavily
+because of high cardinality, such as caching `now` date expressions).
 +
-However, evictions are a difficult metric to evaluate.  Filters are cached on a
+However, evictions are a difficult metric to evaluate. Filters are cached on a
 per-segment basis, and evicting a filter from a small segment is much less
-expensive than evicting a filter from a large segment.  It's possible that you have many evictions, but they all occur on small segments, which means they have
+expensive than evicting a filter from a large segment. It's possible that you
+have many evictions, but they all occur on small segments, which means they have
 little impact on query performance.
 +
-Use the eviction metric as a rough guideline.  If you see a large number, investigate
-your filters to make sure they are caching well.  Filters that constantly evict,
-even on small segments, will be much less effective than properly cached filters.
+Use the eviction metric as a rough guideline. If you see a large number,
+investigate your filters to make sure they are caching well. Filters that
+constantly evict, even on small segments, will be much less effective than
+properly cached filters.
 
-- `field_data` displays the memory used by fielddata,((("fielddata", "statistics on"))) which is used for aggregations,
-sorting, and more.  There is also an eviction count.  Unlike `filter_cache`, the eviction
-count here is useful:  it should be zero or very close.  Since field data
-is not a cache, any eviction is costly and should be avoided.  If you see
-evictions here, you need to reevaluate your memory situation, fielddata limits,
-queries, or all three.
+- `field_data` displays the memory used by fielddata, which is used for
+aggregations, sorting, and more. There is also an eviction count. Unlike
+`filter_cache`, the eviction count here is useful: it should be zero or very
+close. Since field data is not a cache, any eviction is costly and should be
+avoided. If you see evictions here, you need to reevaluate your memory
+situation, fielddata limits, queries, or all three.
 
-- `segments` will tell you the number of Lucene segments this node currently serves.((("segments", "number served by a node")))
-This can be an important number.  Most indices should have around 50&#x2013;150 segments,
-even if they are terabytes in size with billions of documents.  Large numbers
-of segments can indicate a problem with merging (for example, merging is not keeping up
-with segment creation).  Note that this statistic is the aggregate total of all
-indices on the node, so keep that in mind.
+- `segments` will tell you the number of Lucene segments this node currently
+serves. This can be an important number. Most indices should have around
+50&#x2013;150 segments, even if they are terabytes in size with billions of
+documents. Large numbers of segments can indicate a problem with merging (for
+example, merging is not keeping up with segment creation). Note that this
+statistic is the aggregate total of all indices on the node, so keep that in
+mind.
 +
-The `memory` statistic gives you an idea of the amount of memory being used by the
-Lucene segments themselves.((("memory", "statistics on")))  This includes low-level data structures such as
-posting lists, dictionaries, and bloom filters.  A very large number of segments
-will increase the amount of overhead lost to these data structures, and the memory
-usage can be a handy metric to gauge that overhead.
+The `memory` statistic gives you an idea of the amount of memory being used by
+the Lucene segments themselves. This includes low-level data structures such as
+posting lists, dictionaries, and bloom filters. A very large number of segments
+will increase the amount of overhead lost to these data structures, and the
+memory usage can be a handy metric to gauge that overhead.
 
 ==== OS and Process Sections
 
 The `OS` and `Process` sections are fairly self-explanatory and won't be covered
-in great detail.((("operating system (OS), statistics on")))  They list basic resource statistics such as CPU and load.((("process (Elasticsearch JVM), statistics on")))  The
-`OS` section describes it for the entire `OS`, while the `Process` section shows just
-what the Elasticsearch JVM process is using.
+in great detail. They list basic resource statistics such as CPU and load. The
+`OS` section describes it for the entire `OS`, while the `Process` section shows
+just what the Elasticsearch JVM process is using.
 
-These are obviously useful metrics, but are often being measured elsewhere in your
-monitoring stack. Some stats include the following:
+These are obviously useful metrics, but are often being measured elsewhere in
+your monitoring stack. Some stats include the following:
 
 - CPU
 - Load
@@ -215,73 +219,75 @@ monitoring stack. Some stats include the following:
 ==== JVM Section
 
 The `jvm` section contains some critical information about the JVM process that
-is running Elasticsearch.((("JVM (Java Virtual Machine)", "statistics on")))  Most important, it contains garbage collection details,
-which have a large impact on the stability of your Elasticsearch cluster.
+is running Elasticsearch. Most important, it contains garbage collection
+details, which have a large impact on the stability of your Elasticsearch
+cluster.
 
 [[garbage_collector_primer]]
 .Garbage Collection Primer
 **********************************
 Before we describe the stats, it is useful to give a crash course in garbage
-collection and its impact on Elasticsearch.((("garbage collection")))  If you are familar with garbage
+collection and its impact on Elasticsearch. If you are familar with garbage
 collection in the JVM, feel free to skip down.
 
-Java is a _garbage-collected_ language, which means that the programmer does
-not manually manage memory allocation and deallocation.  The programmer simply
-writes code, and the Java Virtual Machine (JVM) manages the process of allocating
+Java is a _garbage-collected_ language, which means that the programmer does not
+manually manage memory allocation and deallocation. The programmer simply writes
+code, and the Java Virtual Machine (JVM) manages the process of allocating
 memory as needed, and then later cleaning up that memory when no longer needed.
 
 When memory is allocated to a JVM process, it is allocated in a big chunk called
-the _heap_.  The JVM then breaks the heap into two groups, referred to as
+the _heap_. The JVM then breaks the heap into two groups, referred to as
 _generations_:
 
 Young (or Eden)::
-    The space where newly instantiated objects are allocated. The
-young generation space is often quite small, usually 100 MB&#x2013;500 MB.  The young-gen
-also contains two _survivor_ spaces.
+    The space where newly instantiated objects are allocated. The young
+generation space is often quite small, usually 100 MB&#x2013;500 MB. The
+young-gen also contains two _survivor_ spaces.
 
 Old::
-    The space where older objects are stored.  These objects are expected to be long-lived
-and persist for a long time.  The old-gen is often much larger than the young-gen,
-and Elasticsearch nodes can see old-gens as large as 30 GB.
+    The space where older objects are stored. These objects are expected to be
+long-lived and persist for a long time. The old-gen is often much larger than
+the young-gen, and Elasticsearch nodes can see old-gens as large as 30 GB.
 
-When an object is instantiated, it is placed into young-gen.  When the young
-generation space is full, a young-gen garbage collection (GC) is started.  Objects that are still
-"alive" are moved into one of the survivor spaces, and "dead" objects are removed.
-If an object has survived several young-gen GCs, it will be "tenured" into the
-old generation.
+When an object is instantiated, it is placed into young-gen. When the young
+generation space is full, a young-gen garbage collection (GC) is started.
+Objects that are still "alive" are moved into one of the survivor spaces, and
+"dead" objects are removed. If an object has survived several young-gen GCs, it
+will be "tenured" into the old generation.
 
-A similar process happens in the old generation:  when the space becomes full, a
+A similar process happens in the old generation: when the space becomes full, a
 garbage collection is started and dead objects are removed.
 
-Nothing comes for free, however.  Both the young- and old-generation garbage collectors
-have phases that "stop the world."  During this time, the JVM literally halts
-execution of the program so it can trace the object graph and collect dead
-objects. During this stop-the-world phase, nothing happens.  Requests are not serviced,
-pings are not responded to, shards are not relocated.  The world quite literally
-stops.
+Nothing comes for free, however. Both the young- and old-generation garbage
+collectors have phases that "stop the world." During this time, the JVM
+literally halts execution of the program so it can trace the object graph and
+collect dead objects. During this stop-the-world phase, nothing happens.
+Requests are not serviced, pings are not responded to, shards are not relocated.
+The world quite literally stops.
 
 This isn't a big deal for the young generation; its small size means GCs execute
-quickly.  But the old-gen is quite a bit larger, and a slow GC here could mean
-1s or even 15s of pausing--which is unacceptable for server software.
+quickly. But the old-gen is quite a bit larger, and a slow GC here could mean 1s
+or even 15s of pausing--which is unacceptable for server software.
 
-The garbage collectors in the JVM are _very_ sophisticated algorithms and do
-a great job minimizing pauses.  And Elasticsearch tries very hard to be _garbage-collection friendly_, by intelligently reusing objects internally, reusing network
-buffers, and enabling <<docvalues>> by default.  But ultimately,
+The garbage collectors in the JVM are _very_ sophisticated algorithms and do a
+great job minimizing pauses. And Elasticsearch tries very hard to be
+_garbage-collection friendly_, by intelligently reusing objects internally,
+reusing network buffers, and enabling <<docvalues>> by default. But ultimately,
 GC frequency and duration is a metric that needs to be watched by you, since it
 is the number one culprit for cluster instability.
 
-A cluster that is frequently experiencing long GC will be a cluster that is under
-heavy load with not enough memory.  These long GCs will make nodes drop off the
-cluster for brief periods.  This instability causes shards to relocate frequently
-as Elasticsearch tries to keep the cluster balanced and enough replicas available.  This in
-turn increases network traffic and disk I/O, all while your cluster is attempting
-to service the normal indexing and query load.
+A cluster that is frequently experiencing long GC will be a cluster that is
+under heavy load with not enough memory. These long GCs will make nodes drop off
+the cluster for brief periods. This instability causes shards to relocate
+frequently as Elasticsearch tries to keep the cluster balanced and enough
+replicas available. This in turn increases network traffic and disk I/O, all
+while your cluster is attempting to service the normal indexing and query load.
 
 In short, long GCs are bad and need to be minimized as much as possible.
 **********************************
 
-Because garbage collection is so critical to Elasticsearch, you should become intimately
-familiar with this section of the `node-stats` API:
+Because garbage collection is so critical to Elasticsearch, you should become
+intimately familiar with this section of the `node-stats` API:
 
 [source,js]
 ----
@@ -298,21 +304,22 @@ familiar with this section of the `node-stats` API:
 
 ----
 
-- The `jvm` section first lists some general stats about heap memory usage.  You
-can see how much of the heap is being used, how much is committed (actually allocated
-to the process), and the max size the heap is allowed to grow to.  Ideally,
-`heap_committed_in_bytes` should be identical to `heap_max_in_bytes`.  If the
-committed size is smaller, the JVM will have to resize the heap eventually--and this is a very expensive process.  If your numbers are not identical, see
-<<heap-sizing>> for how to configure it correctly.
+- The `jvm` section first lists some general stats about heap memory usage. You
+can see how much of the heap is being used, how much is committed (actually
+allocated to the process), and the max size the heap is allowed to grow to.
+Ideally, `heap_committed_in_bytes` should be identical to `heap_max_in_bytes`.
+If the committed size is smaller, the JVM will have to resize the heap
+eventually--and this is a very expensive process. If your numbers are not
+identical, see <<heap-sizing>> for how to configure it correctly.
 +
-The `heap_used_percent` metric is a useful number to keep an eye on.  Elasticsearch
-is configured to initiate GCs when the heap reaches 75% full.  If your node is
-consistently >= 75%, your node is experiencing _memory pressure_.
+The `heap_used_percent` metric is a useful number to keep an eye on.
+Elasticsearch is configured to initiate GCs when the heap reaches 75% full. If
+your node is consistently >= 75%, your node is experiencing _memory pressure_.
 This is a warning sign that slow GCs may be in your near future.
 +
-If the heap usage is consistently >=85%, you are in trouble.  Heaps over 90&#x2013;95%
-are in risk of horrible performance with long 10&#x2013;30s GCs at best, and out-of-memory
-(OOM) exceptions at worst.
+If the heap usage is consistently >=85%, you are in trouble. Heaps over
+90&#x2013;95% are in risk of horrible performance with long 10&#x2013;30s GCs at
+best, and out-of-memory (OOM) exceptions at worst.
 
 [source,js]
 ----
@@ -339,9 +346,10 @@ are in risk of horrible performance with long 10&#x2013;30s GCs at best, and out
 },
 ----
 
-- The `young`, `survivor`, and `old` sections will give you a breakdown of memory
-usage of each generation in the GC.  These stats are handy for keeping an eye on
-relative sizes, but are often not overly important when debugging problems.
+- The `young`, `survivor`, and `old` sections will give you a breakdown of
+memory usage of each generation in the GC. These stats are handy for keeping an
+eye on relative sizes, but are often not overly important when debugging
+problems.
 
 [source,js]
 ----
@@ -360,33 +368,32 @@ relative sizes, but are often not overly important when debugging problems.
 ----
 
 - `gc` section shows the garbage collection counts and cumulative time for both
-young and old generations.  You can safely ignore the young generation counts
-for the most part:  this number will usually be large.  That is perfectly
-normal.
+young and old generations. You can safely ignore the young generation counts for
+the most part: this number will usually be large. That is perfectly normal.
 +
-In contrast, the old generation collection count should remain small, and
-have a small `collection_time_in_millis`.  These are cumulative counts, so it is
-hard to give an exact number when you should start worrying (for example, a node with a
-one-year uptime will have a large count even if it is healthy). This is one of the
-reasons that tools such as Marvel are so helpful.  GC counts _over time_ are the
-important consideration.
+In contrast, the old generation collection count should remain small, and have a
+small `collection_time_in_millis`. These are cumulative counts, so it is hard to
+give an exact number when you should start worrying (for example, a node with a
+one-year uptime will have a large count even if it is healthy). This is one of
+the reasons that tools such as Monitoring are so helpful. GC counts _over time_
+are the important consideration.
 +
-Time spent GC'ing is also important.  For example, a certain amount of garbage
-is generated while indexing documents.  This is normal and causes a GC every
-now and then. These GCs are almost always fast and have little effect on the
-node: young generation takes a millisecond or two, and old generation takes
-a few hundred milliseconds.  This is much different from 10-second GCs.
+Time spent GC'ing is also important. For example, a certain amount of garbage is
+generated while indexing documents. This is normal and causes a GC every now and
+then. These GCs are almost always fast and have little effect on the node: young
+generation takes a millisecond or two, and old generation takes a few hundred
+milliseconds. This is much different from 10-second GCs.
 +
-Our best advice is to collect collection counts and duration periodically (or use Marvel)
-and keep an eye out for frequent GCs.  You can also enable slow-GC logging,
-discussed in <<logging>>.
+Our best advice is to collect collection counts and duration periodically (or
+use Monitoring) and keep an eye out for frequent GCs. You can also enable
+slow-GC logging, discussed in <<logging>>.
 
 ==== Threadpool Section
 
-Elasticsearch maintains threadpools internally. ((("threadpools", "statistics on"))) These threadpools
-cooperate to get work done, passing work between each other as necessary. In
-general, you don't need to configure or tune the threadpools, but it is sometimes
-useful to see their stats so you can gain insight into how your cluster is behaving.
+Elasticsearch maintains threadpools internally. These threadpools cooperate to
+get work done, passing work between each other as necessary. In general, you
+don't need to configure or tune the threadpools, but it is sometimes useful to
+see their stats so you can gain insight into how your cluster is behaving.
 
 There are about a dozen threadpools, but they all share the same format:
 
@@ -402,45 +409,46 @@ There are about a dozen threadpools, but they all share the same format:
   }
 ----
 
-Each threadpool lists the number of threads that are configured (`threads`),
-how many of those threads are actively processing some work (`active`), and how
-many work units are sitting in a queue (`queue`).
+Each threadpool lists the number of threads that are configured (`threads`), how
+many of those threads are actively processing some work (`active`), and how many
+work units are sitting in a queue (`queue`).
 
-If the queue fills up to its limit, new work units will begin to be rejected, and
-you will see that reflected in the `rejected` statistic.  This is often a sign
-that your cluster is starting to bottleneck on some resources, since a full
+If the queue fills up to its limit, new work units will begin to be rejected,
+and you will see that reflected in the `rejected` statistic. This is often a
+sign that your cluster is starting to bottleneck on some resources, since a full
 queue means your node/cluster is processing at maximum speed but unable to keep
 up with the influx of work.
 
 .Bulk Rejections
 ****
-If you are going to encounter queue rejections, it will most likely be caused
-by bulk indexing requests.((("bulk API", "rejections of bulk requests")))  It is easy to send many bulk requests to Elasticsearch
-by using concurrent import processes.  More is better, right?
+If you are going to encounter queue rejections, it will most likely be caused by
+bulk indexing requests. It is easy to send many bulk requests to Elasticsearch
+by using concurrent import processes. More is better, right?
 
 In reality, each cluster has a certain limit at which it can not keep up with
-ingestion.  Once this threshold is crossed, the queue will quickly fill up, and
+ingestion. Once this threshold is crossed, the queue will quickly fill up, and
 new bulks will be rejected.
 
-This is a _good thing_.  Queue rejections are a useful form of back pressure.  They
-let you know that your cluster is at maximum capacity, which is much better than
-sticking data into an in-memory queue.  Increasing the queue size doesn't increase
-performance; it just hides the problem.  If your cluster can process only 10,000
-docs per second, it doesn't matter whether the queue is 100 or 10,000,000--your cluster can
-still process only 10,000 docs per second.
+This is a _good thing_. Queue rejections are a useful form of back pressure.
+They let you know that your cluster is at maximum capacity, which is much better
+than sticking data into an in-memory queue. Increasing the queue size doesn't
+increase performance; it just hides the problem. If your cluster can process
+only 10,000 docs per second, it doesn't matter whether the queue is 100 or
+10,000,000--your cluster can still process only 10,000 docs per second.
 
-The queue simply hides the performance problem and carries a real risk of data-loss.
-Anything sitting in a queue is by definition not processed yet.  If the node
-goes down, all those requests are lost forever.  Furthermore, the queue eats
-up a lot of memory, which is not ideal.
+The queue simply hides the performance problem and carries a real risk of
+data-loss. Anything sitting in a queue is by definition not processed yet. If
+the node goes down, all those requests are lost forever. Furthermore, the queue
+eats up a lot of memory, which is not ideal.
 
 It is much better to handle queuing in your application by gracefully handling
-the back pressure from a full queue.  When you receive bulk rejections, you should take these steps:
+the back pressure from a full queue. When you receive bulk rejections, you
+should take these steps:
 
 1. Pause the import thread for 3&#x2013;5 seconds.
-2. Extract the rejected actions from the bulk response, since it is probable that
-many of the actions were successful. The bulk response will tell you which succeeded
-and which were rejected.
+2. Extract the rejected actions from the bulk response, since it is probable
+that many of the actions were successful. The bulk response will tell you which
+succeeded and which were rejected.
 3. Send a new bulk request with just the rejected actions.
 4. Repeat from step 1 if rejections are encountered again.
 
@@ -450,8 +458,8 @@ naturally backs off.
 Rejections are not errors: they just mean you should try again later.
 ****
 
-There are a dozen threadpools.  Most you can safely ignore, but a few
-are good to keep an eye on:
+There are a dozen threadpools. Most you can safely ignore, but a few are good to
+keep an eye on:
 
 `indexing`::
     Threadpool for normal indexing requests
@@ -470,16 +478,16 @@ are good to keep an eye on:
 
 ==== FS and Network Sections
 
-Continuing down the `node-stats` API, you'll see a((("filesystem, statistics on"))) bunch of statistics about your
-filesystem:  free space, data directory paths, disk I/O stats, and more.  If you are
-not monitoring free disk space, you can get those stats here.  The disk I/O stats
-are also handy, but often more specialized command-line tools (`iostat`, for example)
-are more useful.
+Continuing down the `node-stats` API, you'll see a bunch of statistics about
+your filesystem: free space, data directory paths, disk I/O stats, and more. If
+you are not monitoring free disk space, you can get those stats here. The disk
+I/O stats are also handy, but often more specialized command-line tools
+(`iostat`, for example) are more useful.
 
 Obviously, Elasticsearch has a difficult time functioning if you run out of disk
 space--so make sure you don't.
 
-There are also two sections on ((("network", "statistics on")))network statistics:
+There are also two sections on network statistics:
 
 [source,js]
 ----
@@ -496,21 +504,21 @@ There are also two sections on ((("network", "statistics on")))network statistic
          },
 ----
 
-- `transport` shows some basic stats about the _transport address_.  This
-relates to inter-node communication (often on port 9300) and any transport client
-or node client connections.  Don't worry if you see many connections here;
+- `transport` shows some basic stats about the _transport address_. This relates
+to inter-node communication (often on port 9300) and any transport client or
+node client connections. Don't worry if you see many connections here;
 Elasticsearch maintains a large number of connections between nodes.
 
-- `http` represents stats about the HTTP port (often 9200).  If you see a very
+- `http` represents stats about the HTTP port (often 9200). If you see a very
 large `total_opened` number that is constantly increasing, that is a sure sign
-that one of your HTTP clients is not using keep-alive connections.  Persistent,
-keep-alive connections are important for performance, since building up and tearing
-down sockets is expensive (and wastes file descriptors).  Make sure your clients
-are configured appropriately.
+that one of your HTTP clients is not using keep-alive connections. Persistent,
+keep-alive connections are important for performance, since building up and
+tearing down sockets is expensive (and wastes file descriptors). Make sure your
+clients are configured appropriately.
 
 ==== Circuit Breaker
 
-Finally, we come to the last section: stats about the((("fielddata circuit breaker"))) fielddata circuit breaker
+Finally, we come to the last section: stats about the fielddata circuit breaker
 (introduced in <<circuit-breaker>>):
 
 [role="pagebreak-before"]
@@ -527,11 +535,12 @@ Finally, we come to the last section: stats about the((("fielddata circuit break
 ----
 
 Here, you can determine the maximum circuit-breaker size (for example, at what
-size the circuit breaker will trip if a query attempts to use more memory).  This section
-will also let you know the number of times the circuit breaker has been tripped, and
-the currently configured overhead.  The overhead is used to pad estimates, because some queries are more difficult to estimate than others.
+size the circuit breaker will trip if a query attempts to use more memory). This
+section will also let you know the number of times the circuit breaker has been
+tripped, and the currently configured overhead. The overhead is used to pad
+estimates, because some queries are more difficult to estimate than others.
 
-The main thing to watch is the `tripped` metric.  If this number is large or
+The main thing to watch is the `tripped` metric. If this number is large or
 consistently increasing, it's a sign that your queries may need to be optimized
 or that you may need to obtain more memory (either per box or by adding more
-nodes).((("Node Stats API", range="endofrange", startref="ix_NodeStats")))
+nodes).

--- a/500_Cluster_Admin/40_other_stats.asciidoc
+++ b/500_Cluster_Admin/40_other_stats.asciidoc
@@ -1,16 +1,16 @@
 
 === Cluster Stats
 
-The `cluster-stats` API provides similar output to the `node-stats`.((("clusters", "administration", "Cluster Stats API")))  There
-is one crucial difference: Node Stats shows you statistics per node, while
+The `cluster-stats` API provides similar output to the `node-stats`. There is
+one crucial difference: Node Stats shows you statistics per node, while
 `cluster-stats` shows you the sum total of all nodes in a single metric.
 
-This provides some useful stats to glance at.  You can see for example, that your entire cluster
-is using 50% of the available heap or that filter cache is not evicting heavily.  Its
-main use is to provide a quick summary that is more extensive than
-the `cluster-health`, but less detailed than `node-stats`. It is also useful for
-clusters that are very large, which makes `node-stats` output difficult
-to read.
+This provides some useful stats to glance at. You can see for example, that your
+entire cluster is using 50% of the available heap or that filter cache is not
+evicting heavily. Its main use is to provide a quick summary that is more
+extensive than the `cluster-health`, but less detailed than `node-stats`. It is
+also useful for clusters that are very large, which makes `node-stats` output
+difficult to read.
 
 The API may be invoked as follows:
 
@@ -21,16 +21,16 @@ GET _cluster/stats
 
 === Index Stats
 
-So far, we have been looking at _node-centric_ statistics:((("indices", "index statistics")))((("clusters", "administration", "index stats")))  How much memory does 
-this node have?  How much CPU is being used?  How many searches is this node
+So far, we have been looking at _node-centric_ statistics: How much memory does
+this node have? How much CPU is being used? How many searches is this node
 servicing?
 
 Sometimes it is useful to look at statistics from an _index-centric_ perspective:
 How many search requests is _this index_ receiving?  How much time is spent fetching
 docs in _that index_?
 
-To do this, select the index (or indices) that you are interested in and 
-execute an Index `stats` API:
+To do this, select the index (or indices) that you are interested in and execute
+an Index `stats` API:
 
 [source,js]
 ----
@@ -44,36 +44,36 @@ GET _all/_stats <3>
 <2> Stats for multiple indices can be requested by separating their names with a comma.
 <3> Stats for all indices can be requested using the special `_all` index name.
 
-The stats returned will be familar to the `node-stats` output: `search` `fetch` `get`
-`index` `bulk` `segment counts` and so forth
+The stats returned will be familar to the `node-stats` output: `search` `fetch`
+`get` `index` `bulk` `segment counts` and so forth
 
 Index-centric stats can be useful for identifying or verifying _hot_ indices
 inside your cluster, or trying to determine why some indices are faster/slower
 than others.
 
-In practice, however, node-centric statistics tend to be more useful.  Entire
-nodes tend to bottleneck, not individual indices.  And because indices
-are usually spread across multiple nodes, index-centric statistics
-are usually not very helpful because they aggregate data from different physical machines
+In practice, however, node-centric statistics tend to be more useful. Entire
+nodes tend to bottleneck, not individual indices. And because indices are
+usually spread across multiple nodes, index-centric statistics are usually not
+very helpful because they aggregate data from different physical machines
 operating in different environments.
 
-Index-centric stats are a useful tool to keep in your repertoire, but are not usually
-the first tool to reach for.
+Index-centric stats are a useful tool to keep in your repertoire, but are not
+usually the first tool to reach for.
 
 === Pending Tasks
 
-There are certain tasks that only the master can perform, such as creating a new ((("clusters", "administration", "Pending Tasks API")))
-index or moving shards around the cluster.  Since a cluster can have only one
-master, only one node can ever process cluster-level metadata changes.  For 
-99.9999% of the time, this is never a problem.  The queue of metadata changes
+There are certain tasks that only the master can perform, such as creating a new
+index or moving shards around the cluster. Since a cluster can have only one
+master, only one node can ever process cluster-level metadata changes. For
+99.9999% of the time, this is never a problem. The queue of metadata changes
 remains essentially zero.
 
-In some _rare_ clusters, the number of metadata changes occurs faster than
-the master can process them.  This leads to a buildup of pending actions that
-are queued.
+In some _rare_ clusters, the number of metadata changes occurs faster than the
+master can process them. This leads to a buildup of pending actions that are
+queued.
 
-The `pending-tasks` API ((("Pending Tasks API")))will show you what (if any) cluster-level metadata changes
-are pending in the queue:
+The `pending-tasks` API will show you what (if any) cluster-level metadata
+changes are pending in the queue:
 
 [source,js]
 ----
@@ -89,7 +89,7 @@ Usually, the response will look like this:
 }
 ----
 
-This means there are no pending tasks.  If you have one of the rare clusters that
+This means there are no pending tasks. If you have one of the rare clusters that
 bottlenecks on the master node, your pending task list may look like this:
 
 [source,js]
@@ -106,7 +106,7 @@ bottlenecks on the master node, your pending task list may look like this:
       {
          "insert_order": 46,
          "priority": "HIGH",
-         "source": "shard-started ([foo_2][1], node[tMTocMvQQgGCkj7QDHl3OA], [P], 
+         "source": "shard-started ([foo_2][1], node[tMTocMvQQgGCkj7QDHl3OA], [P],
          s[INITIALIZING]), reason [after recovery from gateway]",
          "time_in_queue_millis": 842,
          "time_in_queue": "842ms"
@@ -114,7 +114,7 @@ bottlenecks on the master node, your pending task list may look like this:
       {
          "insert_order": 45,
          "priority": "HIGH",
-         "source": "shard-started ([foo_2][0], node[tMTocMvQQgGCkj7QDHl3OA], [P], 
+         "source": "shard-started ([foo_2][0], node[tMTocMvQQgGCkj7QDHl3OA], [P],
          s[INITIALIZING]), reason [after recovery from gateway]",
          "time_in_queue_millis": 858,
          "time_in_queue": "858ms"
@@ -123,51 +123,51 @@ bottlenecks on the master node, your pending task list may look like this:
 }
 ----
 
-You can see that tasks are assigned a priority (`URGENT` is processed before `HIGH`,
-for example), the order it was inserted, how long the action has been queued and
-what the action is trying to perform.  In the preceding list, there is a `create-index`
-action and two `shard-started` actions pending.
+You can see that tasks are assigned a priority (`URGENT` is processed before
+`HIGH`, for example), the order it was inserted, how long the action has been
+queued and what the action is trying to perform. In the preceding list, there is
+a `create-index` action and two `shard-started` actions pending.
 
 .When Should I Worry About Pending Tasks?
 ****
-As mentioned, the master node is rarely the bottleneck for clusters.  The only
-time it could bottleneck is if the cluster state is both very large 
-_and_ updated frequently.
+As mentioned, the master node is rarely the bottleneck for clusters. The only
+time it could bottleneck is if the cluster state is both very large _and_
+updated frequently.
 
-For example, if you allow customers to create as many dynamic fields as they wish,
-and have a unique index for each customer every day, your cluster state will grow
-very large.  The cluster state includes (among other things) a list of all indices,
-their types, and the fields for each index.
+For example, if you allow customers to create as many dynamic fields as they
+wish, and have a unique index for each customer every day, your cluster state
+will grow very large. The cluster state includes (among other things) a list of
+all indices, their types, and the fields for each index.
 
 So if you have 100,000 customers, and each customer averages 1,000 fields and 90
 days of retention--that's nine billion fields to keep in the cluster state.
-Whenever this changes, the nodes must be notified.  
+Whenever this changes, the nodes must be notified.
 
 The master must process these changes, which requires nontrivial CPU overhead,
 plus the network overhead of pushing the updated cluster state to all nodes.
 
 It is these clusters that may begin to see cluster-state actions queuing up.
-There is no easy solution to this problem, however.  You have three options:
+There is no easy solution to this problem, however. You have three options:
 
-- Obtain a beefier master node.  Vertical scaling just delays the inevitable, 
-unfortunately. 
-- Restrict the dynamic nature of the documents in some way, so as to limit the 
-cluster-state size.  
+- Obtain a beefier master node.  Vertical scaling just delays the inevitable,
+unfortunately.
+- Restrict the dynamic nature of the documents in some way, so as to limit the
+cluster-state size.
 - Spin up another cluster after a certain threshold has been crossed.
 ****
 
 === cat API
 
-If you work from the command line often, the `cat` APIs will be helpful
-to you.((("Cat API")))((("clusters", "administration", "Cat API")))  Named after the linux `cat` command, these APIs are designed to
-work like *nix command-line tools.
+If you work from the command line often, the `cat` APIs will be helpful to
+you. Named after the linux `cat` command, these APIs are designed to work like
+*nix command-line tools.
 
 They provide statistics that are identical to all the previously discussed APIs
-(Health, `node-stats`, and so forth), but present the output in tabular form instead of 
-JSON.  This is _very_ convenient for a system administrator, and you just want
-to glance over your cluster or find nodes with high memory usage.
+(Health, `node-stats`, and so forth), but present the output in tabular form
+instead of JSON. This is _very_ convenient for a system administrator, and you
+just want to glance over your cluster or find nodes with high memory usage.
 
-Executing a plain `GET` against the `cat` endpoint will show you all available 
+Executing a plain `GET` against the `cat` endpoint will show you all available
 APIs:
 
 [source,bash]
@@ -198,20 +198,20 @@ GET /_cat
 /_cat/fielddata/{fields}
 ----
 
-Many of these APIs should look familiar to you (and yes, that's a cat at the top 
-:) ).  Let's take a look at the Cat Health API:
+Many of these APIs should look familiar to you (and yes, that's a cat at the top
+:) ). Let's take a look at the Cat Health API:
 
 [source,bash]
 ----
 GET /_cat/health
 
-1408723713 12:08:33 elasticsearch_zach yellow 1 1 114 114 0 0 114 
+1408723713 12:08:33 elasticsearch_zach yellow 1 1 114 114 0 0 114
 ----
 
-The first thing you'll notice is that the response is plain text in tabular form,
-not JSON.  The second thing you'll notice is that there are no column headers
-enabled by default.  This is designed to emulate *nix tools, since it is assumed
-that once you become familiar with the output, you no longer want to see
+The first thing you'll notice is that the response is plain text in tabular
+form, not JSON. The second thing you'll notice is that there are no column
+headers enabled by default. This is designed to emulate *nix tools, since it is
+assumed that once you become familiar with the output, you no longer want to see
 the headers.
 
 To enable headers, add the `?v` parameter:
@@ -220,12 +220,12 @@ To enable headers, add the `?v` parameter:
 ----
 GET /_cat/health?v
 
-epoch   time    cluster status node.total node.data shards pri relo init  
-1408[..] 12[..] el[..]  1         1         114 114    0    0     114 
+epoch   time    cluster status node.total node.data shards pri relo init
+1408[..] 12[..] el[..]  1         1         114 114    0    0     114
 unassign
 ----
 
-Ah, much better.  We now see the timestamp, cluster name, status, the number of 
+Ah, much better. We now see the timestamp, cluster name, status, the number of
 nodes in the cluster, and more--all the same information as the `cluster-health`
 API.
 
@@ -235,13 +235,13 @@ Let's look at `node-stats` in the `cat` API:
 ----
 GET /_cat/nodes?v
 
-host         ip            heap.percent ram.percent load node.role master name 
-zacharys-air 192.168.1.131           45          72 1.85 d         *      Zach 
+host         ip            heap.percent ram.percent load node.role master name
+zacharys-air 192.168.1.131           45          72 1.85 d         *      Zach
 ----
 
-We see some stats about the nodes in our cluster, but the output is basic compared
-to the full `node-stats` output. You can
-include many additional metrics, but rather than consulting the documentation, let's just ask the `cat`
+We see some stats about the nodes in our cluster, but the output is basic
+compared to the full `node-stats` output. You can include many additional
+metrics, but rather than consulting the documentation, let's just ask the `cat`
 API what is available.
 
 You can do this by adding `?help` to any API:
@@ -250,118 +250,114 @@ You can do this by adding `?help` to any API:
 ----
 GET /_cat/nodes?help
 
-id               | id,nodeId               | unique node id                          
-pid              | p                       | process id                              
-host             | h                       | host name                               
-ip               | i                       | ip address                              
-port             | po                      | bound transport port                    
-version          | v                       | es version                              
-build            | b                       | es build hash                           
-jdk              | j                       | jdk version                             
-disk.avail       | d,disk,diskAvail        | available disk space                    
-heap.percent     | hp,heapPercent          | used heap ratio                         
-heap.max         | hm,heapMax              | max configured heap                     
-ram.percent      | rp,ramPercent           | used machine memory ratio               
-ram.max          | rm,ramMax               | total machine memory                    
-load             | l                       | most recent load avg                    
-uptime           | u                       | node uptime                             
-node.role        | r,role,dc,nodeRole      | d:data node, c:client node              
-master           | m                       | m:master-eligible, *:current master  
+id               | id,nodeId               | unique node id
+pid              | p                       | process id
+host             | h                       | host name
+ip               | i                       | ip address
+port             | po                      | bound transport port
+version          | v                       | es version
+build            | b                       | es build hash
+jdk              | j                       | jdk version
+disk.avail       | d,disk,diskAvail        | available disk space
+heap.percent     | hp,heapPercent          | used heap ratio
+heap.max         | hm,heapMax              | max configured heap
+ram.percent      | rp,ramPercent           | used machine memory ratio
+ram.max          | rm,ramMax               | total machine memory
+load             | l                       | most recent load avg
+uptime           | u                       | node uptime
+node.role        | r,role,dc,nodeRole      | d:data node, c:client node
+master           | m                       | m:master-eligible, *:current master
 ...
 ...
 ----
 (Note that the output has been truncated for brevity).
 
 The first column shows the full name, the second column shows the short name,
-and the third column offers a brief description about the parameter. Now that
-we know some column names, we can ask for those explicitly by using the `?h`
+and the third column offers a brief description about the parameter. Now that we
+know some column names, we can ask for those explicitly by using the `?h`
 parameter:
 
 [source,bash]
 ----
 GET /_cat/nodes?v&h=ip,port,heapPercent,heapMax
 
-ip            port heapPercent heapMax 
-192.168.1.131 9300          53 990.7mb 
+ip            port heapPercent heapMax
+192.168.1.131 9300          53 990.7mb
 ----
 
-Because the `cat` API tries to behave like *nix utilities, you can pipe the output
-to other tools such as `sort` `grep` or `awk`.  For example, we can find the largest
-index in our cluster by using the following:
+Because the `cat` API tries to behave like *nix utilities, you can pipe the
+output to other tools such as `sort` `grep` or `awk`. For example, we can find
+the largest index in our cluster by using the following:
 
 [source,bash]
 ----
 % curl 'localhost:9200/_cat/indices?bytes=b' | sort -rnk8
 
-yellow test_names         5 1 3476004 0 376324705 376324705 
-yellow .marvel-2014.08.19 1 1  263878 0 160777194 160777194 
-yellow .marvel-2014.08.15 1 1  234482 0 143020770 143020770 
-yellow .marvel-2014.08.09 1 1  222532 0 138177271 138177271 
-yellow .marvel-2014.08.18 1 1  225921 0 138116185 138116185 
-yellow .marvel-2014.07.26 1 1  173423 0 132031505 132031505 
-yellow .marvel-2014.08.21 1 1  219857 0 128414798 128414798 
-yellow .marvel-2014.07.27 1 1   75202 0  56320862  56320862 
-yellow wavelet            5 1    5979 0  54815185  54815185 
-yellow .marvel-2014.07.28 1 1   57483 0  43006141  43006141 
-yellow .marvel-2014.07.21 1 1   31134 0  27558507  27558507 
-yellow .marvel-2014.08.01 1 1   41100 0  27000476  27000476 
-yellow kibana-int         5 1       2 0     17791     17791 
-yellow t                  5 1       7 0     15280     15280 
-yellow website            5 1      12 0     12631     12631 
-yellow agg_analysis       5 1       5 0      5804      5804 
-yellow v2                 5 1       2 0      5410      5410 
-yellow v1                 5 1       2 0      5367      5367 
-yellow bank               1 1      16 0      4303      4303 
-yellow v                  5 1       1 0      2954      2954 
-yellow p                  5 1       2 0      2939      2939 
-yellow b0001_072320141238 5 1       1 0      2923      2923 
-yellow ipaddr             5 1       1 0      2917      2917 
-yellow v2a                5 1       1 0      2895      2895 
-yellow movies             5 1       1 0      2738      2738 
-yellow cars               5 1       0 0      1249      1249 
-yellow wavelet2           5 1       0 0       615       615 
+yellow test_names         5 1 3476004 0 376324705 376324705
+yellow .marvel-2014.08.19 1 1  263878 0 160777194 160777194
+yellow .marvel-2014.08.15 1 1  234482 0 143020770 143020770
+yellow .marvel-2014.08.09 1 1  222532 0 138177271 138177271
+yellow .marvel-2014.08.18 1 1  225921 0 138116185 138116185
+yellow .marvel-2014.07.26 1 1  173423 0 132031505 132031505
+yellow .marvel-2014.08.21 1 1  219857 0 128414798 128414798
+yellow .marvel-2014.07.27 1 1   75202 0  56320862  56320862
+yellow wavelet            5 1    5979 0  54815185  54815185
+yellow .marvel-2014.07.28 1 1   57483 0  43006141  43006141
+yellow .marvel-2014.07.21 1 1   31134 0  27558507  27558507
+yellow .marvel-2014.08.01 1 1   41100 0  27000476  27000476
+yellow kibana-int         5 1       2 0     17791     17791
+yellow t                  5 1       7 0     15280     15280
+yellow website            5 1      12 0     12631     12631
+yellow agg_analysis       5 1       5 0      5804      5804
+yellow v2                 5 1       2 0      5410      5410
+yellow v1                 5 1       2 0      5367      5367
+yellow bank               1 1      16 0      4303      4303
+yellow v                  5 1       1 0      2954      2954
+yellow p                  5 1       2 0      2939      2939
+yellow b0001_072320141238 5 1       1 0      2923      2923
+yellow ipaddr             5 1       1 0      2917      2917
+yellow v2a                5 1       1 0      2895      2895
+yellow movies             5 1       1 0      2738      2738
+yellow cars               5 1       0 0      1249      1249
+yellow wavelet2           5 1       0 0       615       615
 ----
 
 By adding `?bytes=b`, we disable the human-readable formatting on numbers and
-force them to be listed as bytes.  This output is then piped into `sort` so that
+force them to be listed as bytes. This output is then piped into `sort` so that
 our indices are ranked according to size (the eighth column).
 
-Unfortunately, you'll notice that the Marvel indices are clogging up the results,
-and we don't really care about those indices right now.  Let's pipe the output
-through `grep` and remove anything mentioning Marvel:
+Unfortunately, you'll notice that the Marvel indices are clogging up the
+results, and we don't really care about those indices right now. Let's pipe the
+output through `grep` and remove anything mentioning Marvel:
 
 [source,bash]
 ----
 % curl 'localhost:9200/_cat/indices?bytes=b' | sort -rnk8 | grep -v marvel
 
-yellow test_names         5 1 3476004 0 376324705 376324705 
-yellow wavelet            5 1    5979 0  54815185  54815185 
-yellow kibana-int         5 1       2 0     17791     17791 
-yellow t                  5 1       7 0     15280     15280 
-yellow website            5 1      12 0     12631     12631 
-yellow agg_analysis       5 1       5 0      5804      5804 
-yellow v2                 5 1       2 0      5410      5410 
-yellow v1                 5 1       2 0      5367      5367 
-yellow bank               1 1      16 0      4303      4303 
-yellow v                  5 1       1 0      2954      2954 
-yellow p                  5 1       2 0      2939      2939 
-yellow b0001_072320141238 5 1       1 0      2923      2923 
-yellow ipaddr             5 1       1 0      2917      2917 
-yellow v2a                5 1       1 0      2895      2895 
-yellow movies             5 1       1 0      2738      2738 
-yellow cars               5 1       0 0      1249      1249 
-yellow wavelet2           5 1       0 0       615       615 
+yellow test_names         5 1 3476004 0 376324705 376324705
+yellow wavelet            5 1    5979 0  54815185  54815185
+yellow kibana-int         5 1       2 0     17791     17791
+yellow t                  5 1       7 0     15280     15280
+yellow website            5 1      12 0     12631     12631
+yellow agg_analysis       5 1       5 0      5804      5804
+yellow v2                 5 1       2 0      5410      5410
+yellow v1                 5 1       2 0      5367      5367
+yellow bank               1 1      16 0      4303      4303
+yellow v                  5 1       1 0      2954      2954
+yellow p                  5 1       2 0      2939      2939
+yellow b0001_072320141238 5 1       1 0      2923      2923
+yellow ipaddr             5 1       1 0      2917      2917
+yellow v2a                5 1       1 0      2895      2895
+yellow movies             5 1       1 0      2738      2738
+yellow cars               5 1       0 0      1249      1249
+yellow wavelet2           5 1       0 0       615       615
 ----
 
-Voila!  After piping through `grep` (with `-v` to invert the matches), we get
-a sorted list of indices without Marvel cluttering it up.
+Voila! After piping through `grep` (with `-v` to invert the matches), we get a
+sorted list of indices without Marvel cluttering it up.
 
 This is just a simple example of the flexibility of `cat` at the command line.
-Once you get used to using `cat`, you'll see it like any other *nix tool and start
-going crazy with piping, sorting, and grepping.  If you are a system admin and spend
-any time SSH'd into boxes, definitely spend some time getting familiar
+Once you get used to using `cat`, you'll see it like any other *nix tool and
+start going crazy with piping, sorting, and grepping. If you are a system admin
+and spend any time SSH'd into boxes, definitely spend some time getting familiar
 with the `cat` API.
-
-
-
-

--- a/510_Deployment/10_intro.asciidoc
+++ b/510_Deployment/10_intro.asciidoc
@@ -1,14 +1,13 @@
 If you have made it this far in the book, hopefully you've learned a thing or
-two about Elasticsearch and are ready to((("deployment"))) deploy your cluster to production.((("clusters", "deployment", see="deployment")))
-This chapter is not meant to be an exhaustive guide to running your cluster
-in production, but it covers the key things to consider before putting
-your cluster live.
+two about Elasticsearch and are ready to deploy your cluster to production. This
+chapter is not meant to be an exhaustive guide to running your cluster in
+production, but it covers the key things to consider before putting your cluster
+live.
 
 Three main areas are covered:
 
 - Logistical considerations, such as hardware recommendations and deployment
 strategies
 - Configuration changes that are more suited to a production environment
-- Post-deployment considerations, such as security, maximizing indexing performance,
-and backups
-
+- Post-deployment considerations, such as security, maximizing indexing
+performance, and backups

--- a/510_Deployment/20_hardware.asciidoc
+++ b/510_Deployment/20_hardware.asciidoc
@@ -1,116 +1,118 @@
 [[hardware]]
 === Hardware
 
-If you've been following the normal development path, you've probably been playing((("deployment", "hardware")))((("hardware")))
-with Elasticsearch on your laptop or on a small cluster of machines lying around.
-But when it comes time to deploy Elasticsearch to production, there are a few
-recommendations that you should consider.  Nothing is a hard-and-fast rule;
-Elasticsearch is used for a wide range of tasks and on a bewildering array of
-machines.  But these recommendations provide good starting points based on our experience with
-production clusters.
+If you've been following the normal development path, you've probably been
+playing with Elasticsearch on your laptop or on a small cluster of machines
+lying around. But when it comes time to deploy Elasticsearch to production,
+there are a few recommendations that you should consider. Nothing is a
+hard-and-fast rule; Elasticsearch is used for a wide range of tasks and on a
+bewildering array of machines. But these recommendations provide good starting
+points based on our experience with production clusters.
 
 ==== Memory
 
-If there is one resource that you will run out of first, it will likely be memory.((("hardware", "memory")))((("memory")))
-Sorting and aggregations can both be memory hungry, so enough heap space to
-accommodate these is important.((("heap")))  Even when the heap is comparatively small,
-extra memory can be given to the OS filesystem cache.  Because many data structures
-used by Lucene are disk-based formats, Elasticsearch leverages the OS cache to
-great effect.
+If there is one resource that you will run out of first, it will likely be
+memory. Sorting and aggregations can both be memory hungry, so enough heap space
+to accommodate these is important. Even when the heap is comparatively small,
+extra memory can be given to the OS filesystem cache. Because many data
+structures used by Lucene are disk-based formats, Elasticsearch leverages the OS
+cache to great effect.
 
-A machine with 64 GB of RAM is the ideal sweet spot, but 32 GB and 16 GB machines
-are also common.  Less than 8 GB tends to be counterproductive (you end up
-needing many, many small machines), and greater than 64 GB has problems that we will
-discuss in <<heap-sizing>>.
+A machine with 64 GB of RAM is the ideal sweet spot, but 32 GB and 16 GB
+machines are also common. Less than 8 GB tends to be counterproductive (you end
+up needing many, many small machines), and greater than 64 GB has problems that
+we will discuss in <<heap-sizing>>.
 
 ==== CPUs
 
-Most Elasticsearch deployments tend to be rather light on CPU requirements.  As
-such,((("CPUs (central processing units)")))((("hardware", "CPUs"))) the exact processor setup matters less than the other resources.  You should
-choose a modern processor with multiple cores.  Common clusters utilize two- to eight-core machines.
+Most Elasticsearch deployments tend to be rather light on CPU requirements. As
+such, the exact processor setup matters less than the other resources. You
+should choose a modern processor with multiple cores. Common clusters utilize
+two- to eight-core machines.
 
-If you need to choose between faster CPUs or more cores, choose more cores.  The
+If you need to choose between faster CPUs or more cores, choose more cores. The
 extra concurrency that multiple cores offers will far outweigh a slightly faster
 clock speed.
 
 ==== Disks
 
-Disks are important for all clusters,((("disks")))((("hardware", "disks"))) and doubly so for indexing-heavy clusters
-(such as those that ingest log data).  Disks are the slowest subsystem in a server,
-which means that write-heavy clusters can easily saturate their disks, which in
-turn become the bottleneck of the cluster.
+Disks are important for all clusters, and doubly so for indexing-heavy clusters
+(such as those that ingest log data). Disks are the slowest subsystem in a
+server, which means that write-heavy clusters can easily saturate their disks,
+which in turn become the bottleneck of the cluster.
 
-If you can afford SSDs, they are by far superior to any spinning media.  SSD-backed
-nodes see boosts in both query and indexing performance.  If you can afford it,
-SSDs are the way to go.
+If you can afford SSDs, they are by far superior to any spinning media.
+SSD-backed nodes see boosts in both query and indexing performance. If you can
+afford it, SSDs are the way to go.
 
 .Check Your I/O Scheduler
 ****
-If you are using SSDs, make sure your OS I/O scheduler is((("I/O scheduler"))) configured correctly.
+If you are using SSDs, make sure your OS I/O scheduler is configured correctly.
 When you write data to disk, the I/O scheduler decides when that data is
-_actually_ sent to the disk.  The default under most *nix distributions is a
+_actually_ sent to the disk. The default under most *nix distributions is a
 scheduler called `cfq` (Completely Fair Queuing).
 
 This scheduler allocates _time slices_ to each process, and then optimizes the
-delivery of these various queues to the disk.  It is optimized for spinning media:
-the nature of rotating platters means it is more efficient to write data to disk
-based on physical layout.
+delivery of these various queues to the disk. It is optimized for spinning
+media: the nature of rotating platters means it is more efficient to write data
+to disk based on physical layout.
 
 This is inefficient for SSD, however, since there are no spinning platters
-involved.  Instead, `deadline` or `noop` should be used instead.  The deadline
-scheduler optimizes based on how long writes have been pending, while `noop`
-is just a simple FIFO queue.
+involved. Instead, `deadline` or `noop` should be used instead. The deadline
+scheduler optimizes based on how long writes have been pending, while `noop` is
+just a simple FIFO queue.
 
-This simple change can have dramatic impacts.  We've seen a 500-fold improvement
+This simple change can have dramatic impacts. We've seen a 500-fold improvement
 to write throughput just by using the correct scheduler.
 ****
 
-If you use spinning media, try to obtain the fastest disks possible (high-performance server disks, 15k RPM drives).
+If you use spinning media, try to obtain the fastest disks possible
+(high-performance server disks, 15k RPM drives).
 
 Using RAID 0 is an effective way to increase disk speed, for both spinning disks
-and SSD.  There is no need to use mirroring or parity variants of RAID, since
+and SSD. There is no need to use mirroring or parity variants of RAID, since
 high availability is built into Elasticsearch via replicas.
 
-Finally, avoid network-attached storage (NAS).  People routinely claim their
-NAS solution is faster and more reliable than local drives.  Despite these claims,
-we have never seen NAS live up to its hype.  NAS is often slower, displays
-larger latencies with a wider deviation in average latency, and is a single
-point of failure.
+Finally, avoid network-attached storage (NAS). People routinely claim their NAS
+solution is faster and more reliable than local drives. Despite these claims, we
+have never seen NAS live up to its hype. NAS is often slower, displays larger
+latencies with a wider deviation in average latency, and is a single point of
+failure.
 
 ==== Network
 
-A fast and reliable network is obviously important to performance in a distributed((("hardware", "network")))((("network")))
-system.  Low latency helps ensure that nodes can communicate easily, while
-high bandwidth helps shard movement and recovery.  Modern data-center networking
-(1 GbE, 10 GbE) is sufficient for the vast majority of clusters.
+A fast and reliable network is obviously important to performance in a
+distributed system. Low latency helps ensure that nodes can communicate easily,
+while high bandwidth helps shard movement and recovery. Modern data-center
+networking (1 GbE, 10 GbE) is sufficient for the vast majority of clusters.
 
 Avoid clusters that span multiple data centers, even if the data centers are
-colocated in close proximity.  Definitely avoid clusters that span large geographic
-distances.
+colocated in close proximity. Definitely avoid clusters that span large
+geographic distances.
 
 Elasticsearch clusters assume that all nodes are equal--not that half the nodes
 are actually 150ms distant in another data center. Larger latencies tend to
 exacerbate problems in distributed systems and make debugging and resolution
 more difficult.
 
-Similar to the NAS argument, everyone claims that their pipe between data centers is
-robust and low latency. This is true--until it isn't (a network failure will
-happen eventually; you can count on it). From our experience, the hassle of
-managing cross&#x2013;data center clusters is simply not worth the cost.
+Similar to the NAS argument, everyone claims that their pipe between data
+centers is robust and low latency. This is true--until it isn't (a network
+failure will happen eventually; you can count on it). From our experience, the
+hassle of managing cross&#x2013;data center clusters is simply not worth the
+cost.
 
 ==== General Considerations
 
-It is possible nowadays to obtain truly enormous machines:((("hardware", "general considerations")))  hundreds of gigabytes
-of RAM with dozens of CPU cores.  Conversely, it is also possible to spin up
-thousands of small virtual machines in cloud platforms such as EC2.  Which
+It is possible nowadays to obtain truly enormous machines: hundreds of gigabytes
+of RAM with dozens of CPU cores. Conversely, it is also possible to spin up
+thousands of small virtual machines in cloud platforms such as EC2. Which
 approach is best?
 
-In general, it is better to prefer medium-to-large boxes.  Avoid small machines,
-because you don't want to manage a cluster with a thousand nodes, and the overhead
-of simply running Elasticsearch is more apparent on such small boxes.
+In general, it is better to prefer medium-to-large boxes. Avoid small machines,
+because you don't want to manage a cluster with a thousand nodes, and the
+overhead of simply running Elasticsearch is more apparent on such small boxes.
 
-At the same time, avoid the truly enormous machines.  They often lead to imbalanced
-resource usage (for example, all the memory is being used, but none of the CPU) and can
-add logistical complexity if you have to run multiple nodes per machine.
-
-
+At the same time, avoid the truly enormous machines. They often lead to
+imbalanced resource usage (for example, all the memory is being used, but none
+of the CPU) and can add logistical complexity if you have to run multiple nodes
+per machine.

--- a/510_Deployment/30_other.asciidoc
+++ b/510_Deployment/30_other.asciidoc
@@ -2,77 +2,77 @@
 === Java Virtual Machine
 
 You should always run the most recent version of the Java Virtual Machine (JVM),
-unless otherwise stated on the Elasticsearch website.((("deployment", "Java Virtual Machine (JVM)")))((("JVM (Java Virtual Machine)")))((("Java Virtual Machine", see="JVM")))  Elasticsearch, and in
-particular Lucene, is a demanding piece of software.  The unit and integration
-tests from Lucene often expose bugs in the JVM itself.  These bugs range from
-mild annoyances to serious segfaults, so it is best to use the latest version
-of the JVM where possible.
+unless otherwise stated on the Elasticsearch website. Elasticsearch, and in
+particular Lucene, is a demanding piece of software. The unit and integration
+tests from Lucene often expose bugs in the JVM itself. These bugs range from
+mild annoyances to serious segfaults, so it is best to use the latest version of
+the JVM where possible.
 
-Java 8 is preferred over Java 7.  Java 6 is no longer supported.  Either Oracle or OpenJDK are acceptable. They are comparable in performance and stability.
+Java 8 is preferred over Java 7. Java 6 is no longer supported. Either Oracle or
+OpenJDK are acceptable. They are comparable in performance and stability.
 
-If your application is written in Java and you are using the transport client
-or node client, make sure the JVM running your application is identical to the
-server JVM.  In few locations in Elasticsearch, Java's native serialization
-is used (IP addresses, exceptions, and so forth).  Unfortunately, Oracle has been known to
-change the serialization format between minor releases, leading to strange errors.
-This happens rarely, but it is best practice to keep the JVM versions identical
-between client and server.
+If your application is written in Java and you are using the transport client or
+node client, make sure the JVM running your application is identical to the
+server JVM. In few locations in Elasticsearch, Java's native serialization is
+used (IP addresses, exceptions, and so forth). Unfortunately, Oracle has been
+known to change the serialization format between minor releases, leading to
+strange errors. This happens rarely, but it is best practice to keep the JVM
+versions identical between client and server.
 
 .Please Do Not Tweak JVM Settings
 ****
-The JVM exposes dozens (hundreds even!) of settings, parameters, and configurations.((("JVM (Java Virtual Machine)", "avoiding custom configuration")))
-They allow you to tweak and tune almost every aspect of the JVM.
+The JVM exposes dozens (hundreds even!) of settings, parameters, and
+configurations. They allow you to tweak and tune almost every aspect of the JVM.
 
-When a knob is encountered, it is human nature to want to turn it.  We implore
-you to squash this desire and _not_ use custom JVM settings.  Elasticsearch is
-a complex piece of software, and the current JVM settings have been tuned
-over years of real-world usage.
+When a knob is encountered, it is human nature to want to turn it. We implore
+you to squash this desire and _not_ use custom JVM settings. Elasticsearch is a
+complex piece of software, and the current JVM settings have been tuned over
+years of real-world usage.
 
-It is easy to start turning knobs, producing opaque effects that are hard to measure,
-and eventually detune your cluster into a slow, unstable mess.  When debugging
-clusters, the first step is often to remove all custom configurations.  About
-half the time, this alone restores stability and performance.
+It is easy to start turning knobs, producing opaque effects that are hard to
+measure, and eventually detune your cluster into a slow, unstable mess. When
+debugging clusters, the first step is often to remove all custom configurations.
+About half the time, this alone restores stability and performance.
 ****
 
 === Transport Client Versus Node Client
 
-If you are using Java, you may wonder when to use the transport client versus the
-node client.((("Java", "clients for Elasticsearch")))((("clients")))((("node client", "versus transport client")))((("transport client", "versus node client")))  As discussed at the beginning of the book, the transport client
-acts as a communication layer between the cluster and your application.  It knows
-the API and can automatically round-robin between nodes, sniff the cluster for you,
-and more. But it is _external_ to the cluster, similar to the REST clients.
+If you are using Java, you may wonder when to use the transport client versus
+the node client. As discussed at the beginning of the book, the transport client
+acts as a communication layer between the cluster and your application. It knows
+the API and can automatically round-robin between nodes, sniff the cluster for
+you, and more. But it is _external_ to the cluster, similar to the REST clients.
 
 The node client, on the other hand, is actually a node within the cluster (but
-does not hold data, and cannot become master).  Because it is a node, it knows
+does not hold data, and cannot become master). Because it is a node, it knows
 the entire cluster state (where all the nodes reside, which shards live in which
 nodes, and so forth). This means it can execute APIs with one less network hop.
 
 There are uses-cases for both clients:
 
-- The transport client is ideal if you want to decouple your application from the
-cluster.  For example, if your application quickly creates and destroys
-connections to the cluster, a transport client is much "lighter" than a node client,
-since it is not part of a cluster.
+- The transport client is ideal if you want to decouple your application from
+the cluster. For example, if your application quickly creates and destroys
+connections to the cluster, a transport client is much "lighter" than a node
+client, since it is not part of a cluster.
 +
 Similarly, if you need to create thousands of connections, you don't want to
-have thousands of node clients join the cluster.  The TC will be a better choice.
+have thousands of node clients join the cluster. The TC will be a better choice.
 
 - On the flipside, if you need only a few long-lived, persistent connection
 objects to the cluster, a node client can be a bit more efficient since it knows
-the cluster layout.  But it ties your application into the cluster, so it may
+the cluster layout. But it ties your application into the cluster, so it may
 pose problems from a firewall perspective.
 
 === Configuration Management
 
-If you use configuration management already (Puppet, Chef, Ansible), you can skip this tip.((("deployment", "configuration management")))((("configuration management")))
+If you use configuration management already (Puppet, Chef, Ansible), you can
+skip this tip.
 
-If you don't use configuration management tools yet, you should!  Managing
-a handful of servers by `parallel-ssh` may work now, but it will become a nightmare
-as you grow your cluster.  It is almost impossible to edit 30 configuration files
-by hand without making a mistake.
+If you don't use configuration management tools yet, you should! Managing a
+handful of servers by `parallel-ssh` may work now, but it will become a
+nightmare as you grow your cluster. It is almost impossible to edit 30
+configuration files by hand without making a mistake.
 
 Configuration management tools help make your cluster consistent by automating
-the process of config changes.  It may take a little time to set up and learn,
+the process of config changes. It may take a little time to set up and learn,
 but it will pay itself off handsomely over time.
-
-

--- a/510_Deployment/40_config.asciidoc
+++ b/510_Deployment/40_config.asciidoc
@@ -1,34 +1,35 @@
 [[important-configuration-changes]]
 === Important Configuration Changes
-Elasticsearch ships with _very good_ defaults,((("deployment", "configuration changes, important")))((("configuration changes, important"))) especially when it comes to performance-
-related settings and options.  When in doubt, just leave
-the settings alone.  We have witnessed countless dozens of clusters ruined
-by errant settings because the administrator thought he could turn a knob
-and gain 100-fold improvement.
+Elasticsearch ships with _very good_ defaults, especially when it comes to
+performance- related settings and options. When in doubt, just leave the
+settings alone. We have witnessed countless dozens of clusters ruined by errant
+settings because the administrator thought he could turn a knob and gain
+100-fold improvement.
 
 [NOTE]
 ====
-Please read this entire section!  All configurations presented are equally
-important, and are not listed in any particular order.  Please read
-through all configuration options and apply them to your cluster.
+Please read this entire section! All configurations presented are equally
+important, and are not listed in any particular order. Please read through all
+configuration options and apply them to your cluster.
 ====
 
-Other databases may require tuning, but by and large, Elasticsearch does not.
-If you are hitting performance problems, the solution is usually better data
-layout or more nodes.  There are very few "magic knobs" in Elasticsearch.
-If there were, we'd have turned them already!
+Other databases may require tuning, but by and large, Elasticsearch does not. If
+you are hitting performance problems, the solution is usually better data layout
+or more nodes. There are very few "magic knobs" in Elasticsearch. If there were,
+we'd have turned them already!
 
-With that said, there are some _logistical_ configurations that should be changed
-for production.  These changes are necessary either to make your life easier, or because
-there is no way to set a good default (because it depends on your cluster layout).
+With that said, there are some _logistical_ configurations that should be
+changed for production. These changes are necessary either to make your life
+easier, or because there is no way to set a good default (because it depends on
+your cluster layout).
 
 
 ==== Assign Names
 
-Elasticseach by default starts a cluster named `elasticsearch`. ((("configuration changes, important", "assigning names"))) It is wise
-to rename your production cluster to something else, simply to prevent accidents
-whereby someone's laptop joins the cluster.  A simple change to `elasticsearch_production`
-can save a lot of heartache.
+Elasticseach by default starts a cluster named `elasticsearch`. It is wise to
+rename your production cluster to something else, simply to prevent accidents
+whereby someone's laptop joins the cluster. A simple change to
+`elasticsearch_production` can save a lot of heartache.
 
 This can be changed in your `elasticsearch.yml` file:
 
@@ -38,16 +39,18 @@ cluster.name: elasticsearch_production
 ----
 
 Similarly, it is wise to change the names of your nodes. As you've probably
-noticed by now, Elasticsearch assigns a random Marvel superhero name
-to your nodes at startup.  This is cute in development--but less cute when it is
-3a.m. and you are trying to remember which physical machine was Tagak the Leopard Lord.
+noticed by now, Elasticsearch assigns a random Marvel superhero name to your
+nodes at startup. This is cute in development--but less cute when it is 3a.m.
+and you are trying to remember which physical machine was Tagak the Leopard
+Lord.
 
 More important, since these names are generated on startup, each time you
-restart your node, it will get a new name. This can make logs confusing,
-since the names of all the nodes are constantly changing.
+restart your node, it will get a new name. This can make logs confusing, since
+the names of all the nodes are constantly changing.
 
 Boring as it might be, we recommend you give each node a name that makes sense
-to you--a plain, descriptive name.  This is also configured in your `elasticsearch.yml`:
+to you--a plain, descriptive name. This is also configured in your
+`elasticsearch.yml`:
 
 [source,yaml]
 ----
@@ -57,15 +60,16 @@ node.name: elasticsearch_005_data
 
 ==== Paths
 
-By default, Elasticsearch will place the plug-ins,((("configuration changes, important", "paths")))
-((("paths"))) logs, and--most important--your data in the installation directory.  This can lead to
-unfortunate accidents, whereby the installation directory is accidentally overwritten
-by a new installation of Elasticsearch. If you aren't careful, you can erase all your data.
+By default, Elasticsearch will place the plug-ins, logs, and--most
+important--your data in the installation directory. This can lead to unfortunate
+accidents, whereby the installation directory is accidentally overwritten by a
+new installation of Elasticsearch. If you aren't careful, you can erase all your
+data.
 
 Don't laugh--we've seen it happen more than a few times.
 
 The best thing to do is relocate your data directory outside the installation
-location.  You can optionally move your plug-in and log directories as well.
+location. You can optionally move your plug-in and log directories as well.
 
 This can be changed as follows:
 
@@ -79,62 +83,66 @@ path.logs: /path/to/logs
 # Path to where plugins are installed:
 path.plugins: /path/to/plugins
 ----
-<1> Notice that you can specify more than one directory for data by using comma-separated lists.
+<1> Notice that you can specify more than one directory for data by using
+comma-separated lists.
 
-Data can be saved to multiple directories, and if each directory
-is mounted on a different hard drive, this is a simple and effective way to
-set up a software RAID 0.  Elasticsearch will automatically stripe
-data between the different directories, boosting performance.
+Data can be saved to multiple directories, and if each directory is mounted on a
+different hard drive, this is a simple and effective way to set up a software
+RAID 0. Elasticsearch will automatically stripe data between the different
+directories, boosting performance.
 
 .Multiple data path safety and performance
 [WARNING]
 ====================
 Like any RAID 0 configuration, only a single copy of your data is saved to the
-hard drives.  If you lose a hard drive, you are _guaranteed_ to lose a portion
-of your data on that machine.  With luck you'll have replicas elsewhere in the
-cluster which can recover the data, and/or a recent <<backing-up-your-cluster, backup>>.
+hard drives. If you lose a hard drive, you are _guaranteed_ to lose a portion of
+your data on that machine. With luck you'll have replicas elsewhere in the
+cluster which can recover the data, and/or a recent <<backing-up-your-cluster,
+backup>>.
 
 Elasticsearch attempts to minimize the extent of data loss by striping entire
-shards to a drive.  That means that `Shard 0` will be placed entirely on a single
+shards to a drive. That means that `Shard 0` will be placed entirely on a single
 drive. Elasticsearch will not stripe a shard across multiple drives, since the
 loss of one drive would corrupt the entire shard.
 
-This has ramifications for performance: if you are adding multiple drives
-to improve the performance of a single index, it is unlikely to help since
-most nodes will only have one shard, and thus one active drive.  Multiple data
-paths only helps if you have many indices/shards on a single node.
+This has ramifications for performance: if you are adding multiple drives to
+improve the performance of a single index, it is unlikely to help since most
+nodes will only have one shard, and thus one active drive. Multiple data paths
+only helps if you have many indices/shards on a single node.
 
 Multiple data paths is a nice convenience feature, but at the end of the day,
-Elasticsearch is not a software RAID package. If you need more advanced configuration,
-robustness and flexibility, we encourage you to use actual software RAID packages
-instead of the multiple data path feature.
+Elasticsearch is not a software RAID package. If you need more advanced
+configuration, robustness and flexibility, we encourage you to use actual
+software RAID packages instead of the multiple data path feature.
 ====================
 
 ==== Minimum Master Nodes
 
-The `minimum_master_nodes` setting is _extremely_ important to the
-stability of your cluster.((("configuration changes, important", "minimum_master_nodes setting")))((("minimum_master_nodes setting")))  This setting helps prevent _split brains_, the existence of two masters in a single cluster.
+The `minimum_master_nodes` setting is _extremely_ important to the stability of
+your cluster. This setting helps prevent _split brains_, the existence of two
+masters in a single cluster.
 
-When you have a split brain, your cluster is at danger of losing data.  Because
-the master is considered the supreme ruler of the cluster, it decides
-when new indices can be created, how shards are moved, and so forth.  If you have _two_
-masters, data integrity becomes perilous, since you have two nodes
-that think they are in charge.
+When you have a split brain, your cluster is at danger of losing data. Because
+the master is considered the supreme ruler of the cluster, it decides when new
+indices can be created, how shards are moved, and so forth. If you have _two_
+masters, data integrity becomes perilous, since you have two nodes that think
+they are in charge.
 
 This setting tells Elasticsearch to not elect a master unless there are enough
-master-eligible nodes available.  Only then will an election take place.
+master-eligible nodes available. Only then will an election take place.
 
-This setting should always be configured to a quorum (majority) of your master-eligible nodes.((("quorum")))  A quorum is `(number of master-eligible nodes / 2) + 1`.
+This setting should always be configured to a quorum (majority) of your
+master-eligible nodes. A quorum is `(number of master-eligible nodes / 2) + 1`.
 Here are some examples:
 
 - If you have ten regular nodes (can hold data, can become master), a quorum is
 `6`.
-- If you have three dedicated master nodes and a hundred data nodes, the quorum is `2`,
-since you need to count only nodes that are master eligible.
-- If you have two regular nodes, you are in a conundrum.  A quorum would be
-`2`, but this means a loss of one node will make your cluster inoperable.  A
-setting of `1` will allow your cluster to function, but doesn't protect against
-split brain.  It is best to have a minimum of three nodes in situations like this.
+- If you have three dedicated master nodes and a hundred data nodes, the quorum
+is `2`, since you need to count only nodes that are master eligible.
+- If you have two regular nodes, you are in a conundrum. A quorum would be `2`,
+but this means a loss of one node will make your cluster inoperable. A setting
+of `1` will allow your cluster to function, but doesn't protect against split
+brain. It is best to have a minimum of three nodes in situations like this.
 
 This setting can be configured in your `elasticsearch.yml` file:
 
@@ -144,12 +152,12 @@ discovery.zen.minimum_master_nodes: 2
 ----
 
 But because Elasticsearch clusters are dynamic, you could easily add or remove
-nodes that will change the quorum.  It would be extremely irritating if you had
+nodes that will change the quorum. It would be extremely irritating if you had
 to push new configurations to each node and restart your whole cluster just to
 change the setting.
 
 For this reason, `minimum_master_nodes` (and other settings) can be configured
-via a dynamic API call.  You can change the setting while your cluster is online:
+via a dynamic API call. You can change the setting while your cluster is online:
 
 [source,js]
 ----
@@ -161,39 +169,38 @@ PUT /_cluster/settings
 }
 ----
 
-This will become a persistent setting that takes precedence over whatever is
-in the static configuration.  You should modify this setting whenever you add or
+This will become a persistent setting that takes precedence over whatever is in
+the static configuration. You should modify this setting whenever you add or
 remove master-eligible nodes.
 
 ==== Recovery Settings
 
-Several settings affect the behavior of shard recovery when
-your cluster restarts.((("recovery settings")))((("configuration changes, important", "recovery settings")))  First, we need to understand what happens if nothing is
-configured.
+Several settings affect the behavior of shard recovery when your cluster
+restarts. First, we need to understand what happens if nothing is configured.
 
 Imagine you have ten nodes, and each node holds a single shard--either a primary
-or a replica--in a 5 primary / 1 replica index.  You take your
-entire cluster offline for maintenance (installing new drives, for example).  When you
-restart your cluster, it just so happens that five nodes come online before
-the other five.
+or a replica--in a 5 primary / 1 replica index. You take your entire cluster
+offline for maintenance (installing new drives, for example). When you restart
+your cluster, it just so happens that five nodes come online before the other
+five.
 
-Maybe the switch to the other five is being flaky, and they didn't
-receive the restart command right away.  Whatever the reason, you have five nodes
-online.  These five nodes will gossip with each other, elect a master, and form a
-cluster.  They notice that data is no longer evenly distributed, since five
-nodes are missing from the cluster, and immediately start replicating new
-shards between each other.
+Maybe the switch to the other five is being flaky, and they didn't receive the
+restart command right away. Whatever the reason, you have five nodes online.
+These five nodes will gossip with each other, elect a master, and form a
+cluster. They notice that data is no longer evenly distributed, since five nodes
+are missing from the cluster, and immediately start replicating new shards
+between each other.
 
-Finally, your other five nodes turn on and join the cluster.  These nodes see
+Finally, your other five nodes turn on and join the cluster. These nodes see
 that _their_ data is being replicated to other nodes, so they delete their local
-data (since it is now redundant, and may be outdated).  Then the cluster starts
+data (since it is now redundant, and may be outdated). Then the cluster starts
 to rebalance even more, since the cluster size just went from five to ten.
 
 During this whole process, your nodes are thrashing the disk and network, moving
-data around--for no good reason. For large clusters with terabytes of data,
-this useless shuffling of data can take a _really long time_.  If all the nodes
-had simply waited for the cluster to come online, all the data would have been
-local and nothing would need to move.
+data around--for no good reason. For large clusters with terabytes of data, this
+useless shuffling of data can take a _really long time_. If all the nodes had
+simply waited for the cluster to come online, all the data would have been local
+and nothing would need to move.
 
 Now that we know the problem, we can configure a few settings to alleviate it.
 First, we need to give Elasticsearch a hard limit:
@@ -203,11 +210,11 @@ First, we need to give Elasticsearch a hard limit:
 gateway.recover_after_nodes: 8
 ----
 
-This will prevent Elasticsearch from starting a recovery until at least eight (data or master) nodes
-are present.  The value for this setting is a matter of personal preference: how
-many nodes do you want present before you consider your cluster functional?
-In this case, we are setting it to `8`, which means the cluster is inoperable
-unless there are at least eight nodes.
+This will prevent Elasticsearch from starting a recovery until at least eight
+(data or master) nodes are present. The value for this setting is a matter of
+personal preference: how many nodes do you want present before you consider your
+cluster functional? In this case, we are setting it to `8`, which means the
+cluster is inoperable unless there are at least eight nodes.
 
 Then we tell Elasticsearch how many nodes _should_ be in the cluster, and how
 long we want to wait for all those nodes:
@@ -225,12 +232,12 @@ What this means is that Elasticsearch will do the following:
 whichever comes first.
 
 These three settings allow you to avoid the excessive shard swapping that can
-occur on cluster restarts.  It can literally make recovery take seconds instead
+occur on cluster restarts. It can literally make recovery take seconds instead
 of hours.
 
-NOTE: These settings can only be set in the `config/elasticsearch.yml` file or on
-the command line (they are not dynamically updatable) and they are only relevant
-during a full cluster restart.
+NOTE: These settings can only be set in the `config/elasticsearch.yml` file or
+on the command line (they are not dynamically updatable) and they are only
+relevant during a full cluster restart.
 
 [[unicast]]
 ==== Prefer Unicast over Multicast
@@ -239,23 +246,24 @@ Elasticsearch is configured to use unicast discovery out of the box to prevent
 nodes from accidentally joining a cluster. Only nodes running on the same
 machine will automatically form cluster.
 
-While multicast is still https://www.elastic.co/guide/en/elasticsearch/plugins/current/discovery-multicast.html[provided
-as a plugin], it should never be used in production. The
-last thing you want is for nodes to accidentally join your production network, simply
-because they received an errant multicast ping.  There is nothing wrong with
-multicast _per se_.  Multicast simply leads to silly problems, and can be a bit
-more fragile (for example, a network engineer fiddles with the network without telling
+While multicast is still
+https://www.elastic.co/guide/en/elasticsearch/plugins/current/discovery-multicast.html[provided
+as a plugin], it should never be used in production. The last thing you want is
+for nodes to accidentally join your production network, simply because they
+received an errant multicast ping. There is nothing wrong with multicast _per
+se_. Multicast simply leads to silly problems, and can be a bit more fragile
+(for example, a network engineer fiddles with the network without telling
 you--and all of a sudden nodes can't find each other anymore).
 
-To use unicast, you provide Elasticsearch a list of nodes that it should try to contact.
-When a node contacts a member of the unicast list, it receives a full cluster
-state that lists all of the nodes in the cluster.  It then contacts
-the master and joins the cluster.
+To use unicast, you provide Elasticsearch a list of nodes that it should try to
+contact. When a node contacts a member of the unicast list, it receives a full
+cluster state that lists all of the nodes in the cluster. It then contacts the
+master and joins the cluster.
 
-This means your unicast list does not need to include all of the nodes in your cluster.
-It just needs enough nodes that a new node can find someone to talk to.  If you
-use dedicated masters, just list your three dedicated masters and call it a day.
-This setting is configured in `elasticsearch.yml`:
+This means your unicast list does not need to include all of the nodes in your
+cluster. It just needs enough nodes that a new node can find someone to talk to.
+If you use dedicated masters, just list your three dedicated masters and call it
+a day. This setting is configured in `elasticsearch.yml`:
 
 [source,yaml]
 ----

--- a/510_Deployment/45_dont_touch.asciidoc
+++ b/510_Deployment/45_dont_touch.asciidoc
@@ -2,83 +2,79 @@
 === Don't Touch These Settings!
 
 There are a few hotspots in Elasticsearch that people just can't seem to avoid
-tweaking. ((("deployment", "settings to leave unaltered"))) We understand:  knobs just beg to be turned. But of all the knobs to turn, these you should _really_ leave alone. They are
-often abused and will contribute to terrible stability or terrible performance.
-Or both.
+tweaking. We understand: knobs just beg to be turned. But of all the knobs to
+turn, these you should _really_ leave alone. They are often abused and will
+contribute to terrible stability or terrible performance. Or both.
 
 ==== Garbage Collector
 
 As briefly introduced in <<garbage_collector_primer>>, the JVM uses a garbage
-collector to free unused memory.((("garbage collector")))  This tip is really an extension of the last tip,
-but deserves its own section for emphasis:
+collector to free unused memory. This tip is really an extension of the last
+tip, but deserves its own section for emphasis:
 
 Do not change the default garbage collector!
 
-The default GC for Elasticsearch is Concurrent-Mark and Sweep (CMS).((("Concurrent-Mark and Sweep (CMS) garbage collector")))  This GC
+The default GC for Elasticsearch is Concurrent-Mark and Sweep (CMS). This GC
 runs concurrently with the execution of the application so that it can minimize
-pauses.  It does, however, have two stop-the-world phases.  It also has trouble
+pauses. It does, however, have two stop-the-world phases. It also has trouble
 collecting large heaps.
 
-Despite these downsides, it is currently the best GC for low-latency server software
-like Elasticsearch.  The official recommendation is to use CMS.
+Despite these downsides, it is currently the best GC for low-latency server
+software like Elasticsearch. The official recommendation is to use CMS.
 
-There is a newer GC called the Garbage First GC (G1GC). ((("Garbage First GC (G1GC)"))) This newer GC is designed
-to minimize pausing even more than CMS, and operate on large heaps.  It works
-by dividing the heap into regions and predicting which regions contain the most
-reclaimable space.  By collecting those regions first (_garbage first_), it can
-minimize pauses and operate on very large heaps.
+There is a newer GC called the Garbage First GC (G1GC). This newer GC is
+designed to minimize pausing even more than CMS, and operate on large heaps. It
+works by dividing the heap into regions and predicting which regions contain the
+most reclaimable space. By collecting those regions first (_garbage first_), it
+can minimize pauses and operate on very large heaps.
 
-Sounds great!  Unfortunately, G1GC is still new, and fresh bugs are found routinely.
-These bugs are usually of the segfault variety, and will cause hard crashes.
-The Lucene test suite is brutal on GC algorithms, and it seems that G1GC hasn't
-had the kinks worked out yet.
+Sounds great! Unfortunately, G1GC is still new, and fresh bugs are found
+routinely. These bugs are usually of the segfault variety, and will cause hard
+crashes. The Lucene test suite is brutal on GC algorithms, and it seems that
+G1GC hasn't had the kinks worked out yet.
 
 We would like to recommend G1GC someday, but for now, it is simply not stable
 enough to meet the demands of Elasticsearch and Lucene.
 
 ==== Threadpools
 
-Everyone _loves_ to tweak threadpools.((("threadpools")))  For whatever reason, it seems people
-cannot resist increasing thread counts.  Indexing a lot?  More threads!  Searching
-a lot? More threads!  Node idling 95% of the time?  More threads!
+Everyone _loves_ to tweak threadpools. For whatever reason, it seems people
+cannot resist increasing thread counts. Indexing a lot? More threads! Searching
+a lot? More threads! Node idling 95% of the time? More threads!
 
-The default threadpool settings in Elasticsearch are very sensible.  For all
+The default threadpool settings in Elasticsearch are very sensible. For all
 threadpools (except `search`) the threadcount is set to the number of CPU cores.
-If you have eight cores, you can be running only eight threads simultaneously.  It makes
-sense to assign only eight threads to any particular threadpool.
+If you have eight cores, you can be running only eight threads simultaneously.
+It makes sense to assign only eight threads to any particular threadpool.
 
-Search gets a larger threadpool, and is configured to `int((# of cores * 3) / 2) + 1`. 
+Search gets a larger threadpool, and is configured to `int((# of cores * 3) / 2) + 1`.
 
-You might argue that some threads can block (such as on a disk I/O operation), 
-which is why you need more threads.  This is not a problem in Elasticsearch:
-much of the disk I/O is handled by threads managed by Lucene, not Elasticsearch.
+You might argue that some threads can block (such as on a disk I/O operation),
+which is why you need more threads. This is not a problem in Elasticsearch: much
+of the disk I/O is handled by threads managed by Lucene, not Elasticsearch.
 
-Furthermore, threadpools cooperate by passing work between each other.  You don't
+Furthermore, threadpools cooperate by passing work between each other. You don't
 need to worry about a networking thread blocking because it is waiting on a disk
-write.  The networking thread will have long since handed off that work unit to
+write. The networking thread will have long since handed off that work unit to
 another threadpool and gotten back to networking.
 
-Finally, the compute capacity of your process is finite.  Having more threads just forces
-the processor to switch thread contexts.  A processor can run only one thread
-at a time, so when it needs to switch to a different thread, it stores the current
-state (registers, and so forth) and loads another thread.  If you are lucky, the switch
-will happen on the same core.  If you are unlucky, the switch may migrate to a
-different core and require transport on an inter-core communication bus.
+Finally, the compute capacity of your process is finite. Having more threads
+just forces the processor to switch thread contexts. A processor can run only
+one thread at a time, so when it needs to switch to a different thread, it
+stores the current state (registers, and so forth) and loads another thread. If
+you are lucky, the switch will happen on the same core. If you are unlucky, the
+switch may migrate to a different core and require transport on an inter-core
+communication bus.
 
-This context switching eats up cycles simply by doing administrative housekeeping; estimates can peg it as high as 30μs on modern CPUs.  So unless the thread
-will be blocked for longer than 30μs, it is highly likely that that time would
-have been better spent just processing and finishing early.
+This context switching eats up cycles simply by doing administrative
+housekeeping; estimates can peg it as high as 30μs on modern CPUs. So unless the
+thread will be blocked for longer than 30μs, it is highly likely that that time
+would have been better spent just processing and finishing early.
 
-People routinely set threadpools to silly values.  On eight core machines, we have
-run across configs with 60, 100, or even 1000 threads.  These settings will simply
-thrash the CPU more than getting real work done.
+People routinely set threadpools to silly values. On eight core machines, we
+have run across configs with 60, 100, or even 1000 threads. These settings will
+simply thrash the CPU more than getting real work done.
 
-So. Next time you want to tweak a threadpool, please don't.  And if you
+So. Next time you want to tweak a threadpool, please don't. And if you
 _absolutely cannot resist_, please keep your core count in mind and perhaps set
-the count to double.  More than that is just a waste.
-
-
-
-
-
-
+the count to double. More than that is just a waste.

--- a/510_Deployment/50_heap.asciidoc
+++ b/510_Deployment/50_heap.asciidoc
@@ -1,22 +1,22 @@
 [[heap-sizing]]
 === Heap: Sizing and Swapping
 
-The default installation of Elasticsearch is configured with a 1 GB heap. ((("deployment", "heap, sizing and swapping")))((("heap", "sizing and setting"))) For
-just about every deployment, this number is usually too small.  If you are using the
-default heap values, your cluster is probably configured incorrectly.
+The default installation of Elasticsearch is configured with a 1 GB heap. For
+just about every deployment, this number is usually too small. If you are using
+the default heap values, your cluster is probably configured incorrectly.
 
-There are two ways to change the heap size in Elasticsearch.  The easiest is to
-set an environment variable called `ES_HEAP_SIZE`.((("ES_HEAP_SIZE environment variable")))  When the server process
-starts, it will read this environment variable and set the heap accordingly.
-As an example, you can set it via the command line as follows:
+There are two ways to change the heap size in Elasticsearch. The easiest is to
+set an environment variable called `ES_HEAP_SIZE`. When the server process
+starts, it will read this environment variable and set the heap accordingly. As
+an example, you can set it via the command line as follows:
 
 [source,bash]
 ----
 export ES_HEAP_SIZE=10g
 ----
 
-Alternatively, you can pass in the heap size via a command-line argument when starting
-the process, if that is easier for your setup:
+Alternatively, you can pass in the heap size via a command-line argument when
+starting the process, if that is easier for your setup:
 
 [source,bash]
 ----
@@ -25,76 +25,78 @@ the process, if that is easier for your setup:
 <1> Ensure that the min (`Xms`) and max (`Xmx`) sizes are the same to prevent
 the heap from resizing at runtime, a very costly process.
 
-Generally, setting the `ES_HEAP_SIZE` environment variable is preferred over setting
-explicit `-Xmx` and `-Xms` values.
+Generally, setting the `ES_HEAP_SIZE` environment variable is preferred over
+setting explicit `-Xmx` and `-Xms` values.
 
 ==== Give (less than) Half Your Memory to Lucene
 
-A common problem is configuring a heap that is _too_ large. ((("heap", "sizing and setting", "giving half your memory to Lucene"))) You have a 64 GB
-machine--and by golly, you want to give Elasticsearch all 64 GB of memory.  More
+A common problem is configuring a heap that is _too_ large. You have a 64 GB
+machine--and by golly, you want to give Elasticsearch all 64 GB of memory. More
 is better!
 
-Heap is definitely important to Elasticsearch.  It is used by many in-memory data
-structures to provide fast operation.  But with that said, there is another major
+Heap is definitely important to Elasticsearch. It is used by many in-memory data
+structures to provide fast operation. But with that said, there is another major
 user of memory that is _off heap_: Lucene.
 
-Lucene is designed to leverage the underlying OS for caching in-memory data structures.((("Lucene", "memory for")))
-Lucene segments are stored in individual files.  Because segments are immutable,
-these files never change.  This makes them very cache friendly, and the underlying
-OS will happily keep hot segments resident in memory for faster access.  These segments
-include both the inverted index (for fulltext search) and doc values (for aggregations).
+Lucene is designed to leverage the underlying OS for caching in-memory data
+structures. Lucene segments are stored in individual files. Because segments are
+immutable, these files never change. This makes them very cache friendly, and
+the underlying OS will happily keep hot segments resident in memory for faster
+access. These segments include both the inverted index (for fulltext search) and
+doc values (for aggregations).
 
-Lucene's performance relies on this interaction with the OS.  But if you give all
-available memory to Elasticsearch's heap, there won't be any left over for Lucene.
-This can seriously impact the performance.
+Lucene's performance relies on this interaction with the OS. But if you give all
+available memory to Elasticsearch's heap, there won't be any left over for
+Lucene. This can seriously impact the performance.
 
-The standard recommendation is to give 50% of the available memory to Elasticsearch
-heap, while leaving the other 50% free.  It won't go unused; Lucene will happily
-gobble up whatever is left over.
+The standard recommendation is to give 50% of the available memory to
+Elasticsearch heap, while leaving the other 50% free. It won't go unused; Lucene
+will happily gobble up whatever is left over.
 
 If you are not aggregating on analyzed string fields (e.g. you won't be needing
 <<aggregations-and-analysis,fielddata>>) you can consider lowering the heap even
-more.  The smaller you can make the heap, the better performance you can expect
+more. The smaller you can make the heap, the better performance you can expect
 from both Elasticsearch (faster GCs) and Lucene (more memory for caching).
 
 [[compressed_oops]]
 ==== Don't Cross 32 GB!
-There is another reason to not allocate enormous heaps to Elasticsearch. As it turns((("heap", "sizing and setting", "32gb heap boundary")))((("32gb Heap boundary")))
-out, the HotSpot JVM uses a trick to compress object pointers when heaps are less
-than around 32 GB.
+There is another reason to not allocate enormous heaps to Elasticsearch. As it
+turns out, the HotSpot JVM uses a trick to compress object pointers when heaps
+are less than around 32 GB.
 
 In Java, all objects are allocated on the heap and referenced by a pointer.
-Ordinary object pointers (OOP) point at these objects, and are traditionally
-the size of the CPU's native _word_: either 32 bits or 64 bits, depending on the
-processor.  The pointer references the exact byte location of the value.
+Ordinary object pointers (OOP) point at these objects, and are traditionally the
+size of the CPU's native _word_: either 32 bits or 64 bits, depending on the
+processor. The pointer references the exact byte location of the value.
 
-For 32-bit systems, this means the maximum heap size is 4 GB.  For 64-bit systems,
-the heap size can get much larger, but the overhead of 64-bit pointers means there
-is more wasted space simply because the pointer is larger.  And worse than wasted
-space, the larger pointers eat up more bandwidth when moving values between
-main memory and various caches (LLC, L1, and so forth).
+For 32-bit systems, this means the maximum heap size is 4 GB. For 64-bit
+systems, the heap size can get much larger, but the overhead of 64-bit pointers
+means there is more wasted space simply because the pointer is larger. And worse
+than wasted space, the larger pointers eat up more bandwidth when moving values
+between main memory and various caches (LLC, L1, and so forth).
 
-Java uses a trick called https://wikis.oracle.com/display/HotSpotInternals/CompressedOops[compressed oops]((("compressed object pointers")))
-to get around this problem.  Instead of pointing at exact byte locations in
-memory, the pointers reference _object offsets_.((("object offsets")))  This means a 32-bit pointer can
-reference four billion _objects_, rather than four billion bytes.  Ultimately, this
-means the heap can grow to around 32 GB of physical size while still using a 32-bit
-pointer.
+Java uses a trick called
+https://wikis.oracle.com/display/HotSpotInternals/CompressedOops[compressed
+oops] to get around this problem. Instead of pointing at exact byte locations in
+memory, the pointers reference _object offsets_. This means a 32-bit pointer can
+reference four billion _objects_, rather than four billion bytes. Ultimately,
+this means the heap can grow to around 32 GB of physical size while still using
+a 32-bit pointer.
 
 Once you cross that magical ~32 GB boundary, the pointers switch back to
-ordinary object pointers.  The size of each pointer grows, more CPU-memory
-bandwidth is used, and you effectively lose memory.  In fact, it takes until around
-40&#x2013;50 GB of allocated heap before you have the same _effective_ memory of a
-heap just under 32 GB using compressed oops.
+ordinary object pointers. The size of each pointer grows, more CPU-memory
+bandwidth is used, and you effectively lose memory. In fact, it takes until
+around 40&#x2013;50 GB of allocated heap before you have the same _effective_
+memory of a heap just under 32 GB using compressed oops.
 
 The moral of the story is this: even when you have memory to spare, try to avoid
-crossing the 32 GB heap boundary.  It wastes memory, reduces CPU performance, and
+crossing the 32 GB heap boundary. It wastes memory, reduces CPU performance, and
 makes the GC struggle with large heaps.
 
 ==== Just how far under 32gb should I set the JVM?
 
-Unfortunately, that depends.  The exact cutoff varies by JVMs and platforms.
-If you want to play it safe, setting the heap to `31gb` is likely safe.
+Unfortunately, that depends. The exact cutoff varies by JVMs and platforms. If
+you want to play it safe, setting the heap to `31gb` is likely safe.
 Alternatively, you can verify the cutoff point for the HotSpot JVM by adding
 `-XX:+PrintFlagsFinal` to your JVM options and checking that the value of the
 UseCompressedOops flag is true. This will let you find the exact cutoff for your
@@ -126,62 +128,67 @@ The moral of the story is that the exact cutoff to leverage compressed oops
 varies from JVM to JVM, so take caution when taking examples from elsewhere and
 be sure to check your system with your configuration and JVM.
 
-Beginning with Elasticsearch v2.2.0, the startup log will actually tell you if your
-JVM is using compressed OOPs or not.  You'll see a log message like:
+Beginning with Elasticsearch v2.2.0, the startup log will actually tell you if
+your JVM is using compressed OOPs or not. You'll see a log message like:
 
 [source, bash]
 ----
 [2015-12-16 13:53:33,417][INFO ][env] [Illyana Rasputin] heap size [989.8mb], compressed ordinary object pointers [true]
 ----
 
-Which indicates that compressed object pointers are being used.  If they are not,
+Which indicates that compressed object pointers are being used. If they are not,
 the message will say `[false]`.
 
 
 [role="pagebreak-before"]
 .I Have a Machine with 1 TB RAM!
 ****
-The 32 GB line is fairly important.  So what do you do when your machine has a lot
-of memory?  It is becoming increasingly common to see super-servers with 512&#x2013;768 GB
-of RAM.
+The 32 GB line is fairly important. So what do you do when your machine has a
+lot of memory? It is becoming increasingly common to see super-servers with
+512&#x2013;768 GB of RAM.
 
 First, we would recommend avoiding such large machines (see <<hardware>>).
 
 But if you already have the machines, you have three practical options:
 
-- Are you doing mostly full-text search?  Consider giving 4-32 GB to Elasticsearch
-and letting Lucene use the rest of memory via the OS filesystem cache.  All that
-memory will cache segments and lead to blisteringly fast full-text search.
+- Are you doing mostly full-text search? Consider giving 4-32 GB to
+Elasticsearch and letting Lucene use the rest of memory via the OS filesystem
+cache. All that memory will cache segments and lead to blisteringly fast
+full-text search.
 
-- Are you doing a lot of sorting/aggregations?  Are most of your aggregations on numerics,
-dates, geo_points and `not_analyzed` strings?  You're in luck, your aggregations will be done on
-memory-friendly doc values!  Give Elasticsearch somewhere from 4-32 GB of memory and leave the 
-rest for the OS to cache doc values in memory.
+- Are you doing a lot of sorting/aggregations? Are most of your aggregations on
+numerics, dates, geo_points and `not_analyzed` strings? You're in luck, your
+aggregations will be done on memory-friendly doc values! Give Elasticsearch
+somewhere from 4-32 GB of memory and leave the rest for the OS to cache doc
+values in memory.
 
-- Are you doing a lot of sorting/aggregations on analyzed strings (e.g. for word-tags,
-or SigTerms, etc)?  Unfortunately that means you'll need fielddata, which means you
-need heap space.  Instead of one node with a huge amount of RAM, consider running two or
-more nodes on a single machine.  Still adhere to the 50% rule, though.  
+- Are you doing a lot of sorting/aggregations on analyzed strings (e.g. for
+word-tags, or SigTerms, etc)? Unfortunately that means you'll need fielddata,
+which means you need heap space. Instead of one node with a huge amount of RAM,
+consider running two or more nodes on a single machine. Still adhere to the 50%
+rule, though.
 +
-So if your machine has 128 GB of RAM, run two nodes each with just under 32 GB.  This means that less
-than 64 GB will be used for heaps, and more than 64 GB will be left over for Lucene.
+So if your machine has 128 GB of RAM, run two nodes each with just under 32 GB.
+This means that less than 64 GB will be used for heaps, and more than 64 GB will
+be left over for Lucene.
 +
-If you choose this option, set `cluster.routing.allocation.same_shard.host: true`
-in your config.  This will prevent a primary and a replica shard from colocating
-to the same physical machine (since this would remove the benefits of replica high availability).
+If you choose this option, set `cluster.routing.allocation.same_shard.host:
+true` in your config. This will prevent a primary and a replica shard from
+colocating to the same physical machine (since this would remove the benefits of
+replica high availability).
 ****
 
 ==== Swapping Is the Death of Performance
 
-It should be obvious,((("heap", "sizing and setting", "swapping, death of performance")))((("memory", "swapping as the death of performance")))((("swapping, the death of performance"))) but it bears spelling out clearly: swapping main memory
-to disk will _crush_ server performance.  Think about it: an in-memory operation
-is one that needs to execute quickly.
+It should be obvious, but it bears spelling out clearly: swapping main memory to
+disk will _crush_ server performance. Think about it: an in-memory operation is
+one that needs to execute quickly.
 
 If memory swaps to disk, a 100-microsecond operation becomes one that take 10
-milliseconds.  Now repeat that increase in latency for all other 10us operations.
+milliseconds. Now repeat that increase in latency for all other 10us operations.
 It isn't difficult to see why swapping is terrible for performance.
 
-The best thing to do is disable swap completely on your system.  This can be done
+The best thing to do is disable swap completely on your system. This can be done
 temporarily:
 
 [source,bash]
@@ -189,13 +196,13 @@ temporarily:
 sudo swapoff -a
 ----
 
-To disable it permanently, you'll likely need to edit your `/etc/fstab`.  Consult
+To disable it permanently, you'll likely need to edit your `/etc/fstab`. Consult
 the documentation for your OS.
 
-If disabling swap completely is not an option, you can try to lower `swappiness`.
-This value controls how aggressively the OS tries to swap memory.
-This prevents swapping under normal circumstances, but still allows the OS to swap
-under emergency memory situations.
+If disabling swap completely is not an option, you can try to lower
+`swappiness`. This value controls how aggressively the OS tries to swap memory.
+This prevents swapping under normal circumstances, but still allows the OS to
+swap under emergency memory situations.
 
 For most Linux systems, this is configured using the `sysctl` value:
 
@@ -203,12 +210,12 @@ For most Linux systems, this is configured using the `sysctl` value:
 ----
 vm.swappiness = 1 <1>
 ----
-<1> A `swappiness` of `1` is better than `0`, since on some kernel versions a `swappiness`
-of `0` can invoke the OOM-killer.
+<1> A `swappiness` of `1` is better than `0`, since on some kernel versions a
+`swappiness` of `0` can invoke the OOM-killer.
 
-Finally, if neither approach is possible, you should enable `mlockall`.
- file.  This allows the JVM to lock its memory and prevent
-it from being swapped by the OS.  In your `elasticsearch.yml`, set this:
+Finally, if neither approach is possible, you should enable `mlockall`. file.
+ This allows the JVM to lock its memory and prevent it from being swapped by
+ the OS. In your `elasticsearch.yml`, set this:
 
 [source,yaml]
 ----

--- a/510_Deployment/60_file_descriptors.asciidoc
+++ b/510_Deployment/60_file_descriptors.asciidoc
@@ -1,21 +1,21 @@
 
-=== File Descriptors and MMap 
+=== File Descriptors and MMap
 
-Lucene uses a _very_ large number of files. ((("deployment", "file descriptors and MMap"))) At the same time, Elasticsearch
-uses a large number of sockets to communicate between nodes and HTTP clients.
-All of this requires available file descriptors.((("file descriptors")))
+Lucene uses a _very_ large number of files. At the same time, Elasticsearch uses
+a large number of sockets to communicate between nodes and HTTP clients. All of
+this requires available file descriptors.
 
 Sadly, many modern Linux distributions ship with a paltry 1,024 file descriptors
-allowed per process.  This is _far_ too low for even a small Elasticsearch
-node, let alone one that is handling hundreds of indices.
+allowed per process. This is _far_ too low for even a small Elasticsearch node,
+let alone one that is handling hundreds of indices.
 
 You should increase your file descriptor count to something very large, such as
-64,000.  This process is irritatingly difficult and highly dependent on your
-particular OS and distribution.  Consult the documentation for your OS to determine
-how best to change the allowed file descriptor count.
+64,000. This process is irritatingly difficult and highly dependent on your
+particular OS and distribution. Consult the documentation for your OS to
+determine how best to change the allowed file descriptor count.
 
-Once you think you've changed it, check Elasticsearch to make sure it really does
-have enough file descriptors:
+Once you think you've changed it, check Elasticsearch to make sure it really
+does have enough file descriptors:
 
 [source,js]
 ----
@@ -47,20 +47,17 @@ have enough file descriptors:
   }
 }
 ----
-<1> The `max_file_descriptors` field shows the number of available descriptors that
-the Elasticsearch process can access.
+<1> The `max_file_descriptors` field shows the number of available descriptors
+that the Elasticsearch process can access.
 
-Elasticsearch also uses a mix of NioFS and MMapFS ((("MMapFS")))for the various files.  Ensure
-that you configure the maximum map count so that there is ample virtual memory available for 
-mmapped files.  This can be set temporarily:
+Elasticsearch also uses a mix of NioFS and MMapFS ((("MMapFS")))for the various
+files. Ensure that you configure the maximum map count so that there is ample
+virtual memory available for mmapped files. This can be set temporarily:
 
 [source,js]
 ----
 sysctl -w vm.max_map_count=262144
 ----
 
-Or you can set it permanently by modifying `vm.max_map_count` setting in your `/etc/sysctl.conf`.
-
-
-
-
+Or you can set it permanently by modifying `vm.max_map_count` setting in your
+`/etc/sysctl.conf`.

--- a/510_Deployment/70_conclusion.asciidoc
+++ b/510_Deployment/70_conclusion.asciidoc
@@ -1,17 +1,17 @@
 
 === Revisit This List Before Production
 
-You are likely reading this section before you go into production.  
-The details covered in this chapter are good to be generally aware of, but it is 
-critical to revisit this entire list right before deploying to production.
+You are likely reading this section before you go into production. The details
+covered in this chapter are good to be generally aware of, but it is critical to
+revisit this entire list right before deploying to production.
 
 Some of the topics will simply stop you cold (such as too few available file
-descriptors).  These are easy enough to debug because they are quickly apparent.
+descriptors). These are easy enough to debug because they are quickly apparent.
 Other issues, such as split brains and memory settings, are visible only after
-something bad happens.  At that point, the resolution is often messy and tedious.
+something bad happens. At that point, the resolution is often messy and tedious.
 
-It is much better to proactively prevent these situations from occurring by configuring
-your cluster appropriately _before_ disaster strikes.  So if you are going to
-dog-ear (or bookmark) one section from the entire book, this chapter would be
-a good candidate.  The week before deploying to production, simply flip through
-the list presented here and check off all the recommendations.
+It is much better to proactively prevent these situations from occurring by
+configuring your cluster appropriately _before_ disaster strikes. So if you are
+going to dog-ear (or bookmark) one section from the entire book, this chapter
+would be a good candidate. The week before deploying to production, simply flip
+through the list presented here and check off all the recommendations.

--- a/520_Post_Deployment/10_dynamic_settings.asciidoc
+++ b/520_Post_Deployment/10_dynamic_settings.asciidoc
@@ -2,19 +2,19 @@
 === Changing Settings Dynamically
 
 Many settings in Elasticsearch are dynamic and can be modified through the API.
-Configuration changes that force a node (or cluster) restart are strenuously avoided.((("post-deployment", "changing settings dynamically")))
-And while it's possible to make the changes through the static configs, we
-recommend that you use the API instead.
+Configuration changes that force a node (or cluster) restart are strenuously
+avoided. And while it's possible to make the changes through the static configs,
+we recommend that you use the API instead.
 
 The `cluster-update` API operates((("Cluster Update API"))) in two modes:
 
-Transient:: 
-    These changes are in effect until the cluster restarts.  Once
-a full cluster restart takes place, these settings are erased.
+Transient::
+    These changes are in effect until the cluster restarts. Once a full cluster
+restart takes place, these settings are erased.
 
 Persistent::
-    These changes are permanently in place unless explicitly changed.
-They will survive full cluster restarts and override the static configuration files.
+    These changes are permanently in place unless explicitly changed. They will
+survive full cluster restarts and override the static configuration files.
 
 Transient versus persistent settings are supplied in the JSON body:
 
@@ -31,9 +31,7 @@ PUT /_cluster/settings
 }
 ----
 <1> This persistent setting will survive full cluster restarts.
-<2> This transient setting will be removed after the first full cluster 
-restart.
+<2> This transient setting will be removed after the first full cluster restart.
 
 A complete list of settings that can be updated dynamically can be found in the
 {ref}/cluster-update-settings.html[online reference docs].
-

--- a/520_Post_Deployment/20_logging.asciidoc
+++ b/520_Post_Deployment/20_logging.asciidoc
@@ -1,19 +1,20 @@
 [[logging]]
 === Logging
 
-Elasticsearch emits a number of logs, which are placed in  `ES_HOME/logs`.
-The default logging level is `INFO`. ((("post-deployment", "logging")))((("logging", "Elasticsearch logging"))) It provides a moderate amount of information,
+Elasticsearch emits a number of logs, which are placed in `ES_HOME/logs`. The
+default logging level is `INFO`. It provides a moderate amount of information,
 but is designed to be rather light so that your logs are not enormous.
 
 When debugging problems, particularly problems with node discovery (since this
-often depends on finicky network configurations), it can be helpful to bump
-up the logging level to `DEBUG`.
+often depends on finicky network configurations), it can be helpful to bump up
+the logging level to `DEBUG`.
 
 You _could_ modify the `logging.yml` file and restart your nodes--but that is
-both tedious and leads to unnecessary downtime.  Instead, you can update logging
-levels through the `cluster-settings` API((("Cluster Settings API, updating logging levels"))) that we just learned about.
+both tedious and leads to unnecessary downtime. Instead, you can update logging
+levels through the `cluster-settings` API that we just learned about.
 
-To do so, take the logger you are interested in and prepend `logger.` to it. You can refer to the root logger as `logger._root`.
+To do so, take the logger you are interested in and prepend `logger.` to it. You
+can refer to the root logger as `logger._root`.
 
 Let's turn up the discovery logging:
 
@@ -30,19 +31,19 @@ PUT /_cluster/settings
 While this setting is in effect, Elasticsearch will begin to emit `DEBUG`-level
 logs for the `discovery` module.
 
-TIP: Avoid `TRACE`. It is extremely verbose, to the point where the logs
-are no longer useful.
+TIP: Avoid `TRACE`. It is extremely verbose, to the point where the logs are no
+longer useful.
 
 [[slowlog]]
 ==== Slowlog
 
-There is another log called the _slowlog_.  The purpose of((("Slowlog"))) this log is to catch
-queries and indexing requests that take over a certain threshold of time.
-It is useful for hunting down user-generated queries that are particularly slow.
+There is another log called the _slowlog_. The purpose of this log is to catch
+queries and indexing requests that take over a certain threshold of time. It is
+useful for hunting down user-generated queries that are particularly slow.
 
-By default, the slowlog is not enabled.  It can be enabled by defining the action
-(query, fetch, or index), the level that you want the event logged at (`WARN`, `DEBUG`,
-and so forth) and a time threshold.
+By default, the slowlog is not enabled. It can be enabled by defining the action
+(query, fetch, or index), the level that you want the event logged at (`WARN`,
+`DEBUG`, and so forth) and a time threshold.
 
 This is an index-level setting, which means it is applied to individual indices:
 
@@ -59,7 +60,7 @@ PUT /my_index/_settings
 <2> Emit a `DEBUG` log when fetches are slower than 500ms.
 <3> Emit an `INFO` log when indexing takes longer than 5s.
 
-You can also define these thresholds in your `elasticsearch.yml` file.  Indices
+You can also define these thresholds in your `elasticsearch.yml` file. Indices
 that do not have a threshold set will inherit whatever is configured in the
 static config.
 
@@ -78,5 +79,3 @@ PUT /_cluster/settings
 ----
 <1> Set the search slowlog to `DEBUG` level.
 <2> Set the indexing slowlog to `WARN` level.
-
-

--- a/520_Post_Deployment/30_indexing_perf.asciidoc
+++ b/520_Post_Deployment/30_indexing_perf.asciidoc
@@ -1,15 +1,15 @@
 [[indexing-performance]]
 === Indexing Performance Tips
 
-If you are in an indexing-heavy environment,((("indexing", "performance tips")))((("post-deployment", "indexing performance tips"))) such as indexing infrastructure
-logs, you may be willing to sacrifice some search performance for faster indexing
-rates.  In these scenarios, searches tend to be relatively rare and performed
-by people internal to your organization.  They are willing to wait several
-seconds for a search, as opposed to a consumer facing a search that must
+If you are in an indexing-heavy environment, such as indexing infrastructure
+logs, you may be willing to sacrifice some search performance for faster
+indexing rates. In these scenarios, searches tend to be relatively rare and
+performed by people internal to your organization. They are willing to wait
+several seconds for a search, as opposed to a consumer facing a search that must
 return in milliseconds.
 
-Because of this unique position, certain trade-offs can be made
-that will increase your indexing performance.
+Because of this unique position, certain trade-offs can be made that will
+increase your indexing performance.
 
 .These Tips Apply Only to Elasticsearch 1.3+
 ****
@@ -25,87 +25,95 @@ older versions because of the presence of bugs or performance defects.
 ==== Test Performance Scientifically
 
 Performance testing is always difficult, so try to be as scientific as possible
-in your approach.((("performance testing")))((("indexing", "performance tips", "performance testing")))  Randomly fiddling with knobs and turning on ingestion is not
-a good way to tune performance.  If there are too many _causes_, it is impossible
-to determine which one had the best _effect_. A reasonable approach to testing is as follows:
+in your approach. Randomly fiddling with knobs and turning on ingestion is not a
+good way to tune performance. If there are too many _causes_, it is impossible
+to determine which one had the best _effect_. A reasonable approach to testing
+is as follows:
 
 1. Test performance on a single node, with a single shard and no replicas.
 2. Record performance under 100% default settings so that you have a baseline to
 measure against.
 3. Make sure performance tests run for a long time (30+ minutes) so you can
-evaluate long-term performance, not short-term spikes or latencies.  Some events
+evaluate long-term performance, not short-term spikes or latencies. Some events
 (such as segment merging, and GCs) won't happen right away, so the performance
 profile can change over time.
-4. Begin making single changes to the baseline defaults.  Test these rigorously,
-and if performance improvement is acceptable, keep the setting and move on to the
-next one.
+4. Begin making single changes to the baseline defaults. Test these rigorously,
+and if performance improvement is acceptable, keep the setting and move on to
+the next one.
 
 ==== Using and Sizing Bulk Requests
 
-This should be fairly obvious, but use bulk indexing requests for optimal performance.((("indexing", "performance tips", "bulk requests, using and sizing")))((("bulk API", "using and sizing bulk requests")))
-Bulk sizing is dependent on your data, analysis, and cluster configuration, but
-a good starting point is 5&#x2013;15 MB per bulk.  Note that this is physical size.
-Document count is not a good metric for bulk size.  For example, if you are
-indexing 1,000 documents per bulk, keep the following in mind:
+This should be fairly obvious, but use bulk indexing requests for optimal
+performance. Bulk sizing is dependent on your data, analysis, and cluster
+configuration, but a good starting point is 5&#x2013;15 MB per bulk. Note that
+this is physical size. Document count is not a good metric for bulk size. For
+example, if you are indexing 1,000 documents per bulk, keep the following in
+mind:
 
 - 1,000 documents at 1 KB each is 1 MB.
 - 1,000 documents at 100 KB each is 100 MB.
 
-Those are drastically different bulk sizes.  Bulks need to be loaded into memory
+Those are drastically different bulk sizes. Bulks need to be loaded into memory
 at the coordinating node, so it is the physical size of the bulk that is more
 important than the document count.
 
-Start with a bulk size around 5&#x2013;15 MB and slowly increase it until you do not
-see performance gains anymore.  Then start increasing the concurrency of your
+Start with a bulk size around 5&#x2013;15 MB and slowly increase it until you do
+not see performance gains anymore. Then start increasing the concurrency of your
 bulk ingestion (multiple threads, and so forth).
 
-Monitor your nodes with Marvel and/or tools such as `iostat`, `top`, and `ps` to see
-when resources start to bottleneck.  If you start to receive `EsRejectedExecutionException`,
-your cluster can no longer keep up: at least one resource has reached capacity. Either reduce concurrency, provide more of the limited resource (such as switching from spinning disks to SSDs), or add more nodes.
+Monitor your nodes with Marvel and/or tools such as `iostat`, `top`, and `ps` to
+see when resources start to bottleneck. If you start to receive
+`EsRejectedExecutionException`, your cluster can no longer keep up: at least one
+resource has reached capacity. Either reduce concurrency, provide more of the
+limited resource (such as switching from spinning disks to SSDs), or add more
+nodes.
 
 [NOTE]
 ====
 When ingesting data, make sure bulk requests are round-robined across all your
-data nodes.  Do not send all requests to a single node, since that single node
+data nodes. Do not send all requests to a single node, since that single node
 will need to store all the bulks in memory while processing.
 ====
 
 ==== Storage
 
-Disks are usually the bottleneck of any modern server.  Elasticsearch heavily uses disks, and the more throughput your disks can handle, the more stable your nodes will be. Here are some tips for optimizing disk I/O:
+Disks are usually the bottleneck of any modern server. Elasticsearch heavily
+uses disks, and the more throughput your disks can handle, the more stable your
+nodes will be. Here are some tips for optimizing disk I/O:
 
-- Use SSDs.  As mentioned elsewhere, ((("storage")))((("indexing", "performance tips", "storage")))they are superior to spinning media.
-- Use RAID 0.  Striped RAID will increase disk I/O, at the obvious expense of
-potential failure if a drive dies.  Don't use mirrored or parity RAIDS since
+- Use SSDs. As mentioned elsewhere, they are superior to spinning media.
+- Use RAID 0. Striped RAID will increase disk I/O, at the obvious expense of
+potential failure if a drive dies. Don't use mirrored or parity RAIDS since
 replicas provide that functionality.
-- Alternatively, use multiple drives and allow Elasticsearch to stripe data across
-them via multiple `path.data` directories.
-- Do not use remote-mounted storage, such as NFS or SMB/CIFS.  The latency introduced
-here is antithetical to performance.
-- If you are on EC2, beware of EBS.  Even the SSD-backed EBS options are often slower
-than local instance storage.
+- Alternatively, use multiple drives and allow Elasticsearch to stripe data
+across them via multiple `path.data` directories.
+- Do not use remote-mounted storage, such as NFS or SMB/CIFS. The latency
+introduced here is antithetical to performance.
+- If you are on EC2, beware of EBS. Even the SSD-backed EBS options are often
+slower than local instance storage.
 
 [[segments-and-merging]]
 ==== Segments and Merging
 
-Segment merging is computationally expensive,((("indexing", "performance tips", "segments and merging")))((("merging segments")))((("segments", "merging"))) and can eat up a lot of disk I/O.
+Segment merging is computationally expensive, and can eat up a lot of disk I/O.
 Merges are scheduled to operate in the background because they can take a long
-time to finish, especially large segments.  This is normally fine, because the
+time to finish, especially large segments. This is normally fine, because the
 rate of large segment merges is relatively rare.
 
-But sometimes merging falls behind the ingestion rate.  If this happens, Elasticsearch
-will automatically throttle indexing requests to a single thread.  This prevents
-a _segment explosion_ problem, in which hundreds of segments are generated before
-they can be merged. Elasticsearch will log `INFO`-level messages stating `now
-throttling indexing` when it detects merging falling behind indexing.
+But sometimes merging falls behind the ingestion rate. If this happens,
+Elasticsearch will automatically throttle indexing requests to a single thread.
+This prevents a _segment explosion_ problem, in which hundreds of segments are
+generated before they can be merged. Elasticsearch will log `INFO`-level
+messages stating `now throttling indexing` when it detects merging falling
+behind indexing.
 
 Elasticsearch defaults here are conservative: you don't want search performance
-to be impacted by background merging.  But sometimes (especially on SSD, or logging
-scenarios), the throttle limit is too low.
+to be impacted by background merging. But sometimes (especially on SSD, or
+logging scenarios), the throttle limit is too low.
 
-The default is 20 MB/s, which is a good setting for spinning disks.  If you have
-SSDs, you might consider increasing this to 100&#x2013;200 MB/s.  Test to see what works
-for your system:
+The default is 20 MB/s, which is a good setting for spinning disks. If you have
+SSDs, you might consider increasing this to 100&#x2013;200 MB/s. Test to see
+what works for your system:
 
 [source,js]
 ----
@@ -117,9 +125,9 @@ PUT /_cluster/settings
 }
 ----
 
-If you are doing a bulk import and don't care about search at all, you can disable
-merge throttling entirely.  This will allow indexing to run as fast as your
-disks will allow:
+If you are doing a bulk import and don't care about search at all, you can
+disable merge throttling entirely. This will allow indexing to run as fast as
+your disks will allow:
 
 [source,js]
 ----
@@ -130,7 +138,7 @@ PUT /_cluster/settings
     }
 }
 ----
-<1> Setting the throttle type to `none` disables merge throttling entirely.  When
+<1> Setting the throttle type to `none` disables merge throttling entirely. When
 you are done importing, set it back to `merge` to reenable throttling.
 
 If you are using spinning media instead of SSD, you need to add this to your
@@ -141,47 +149,50 @@ If you are using spinning media instead of SSD, you need to add this to your
 index.merge.scheduler.max_thread_count: 1
 ----
 
-Spinning media has a harder time with concurrent I/O, so we need to decrease
-the number of threads that can concurrently access the disk per index.  This setting
-will allow `max_thread_count + 2` threads to operate on the disk at one time,
-so a setting of `1` will allow three threads.
+Spinning media has a harder time with concurrent I/O, so we need to decrease the
+number of threads that can concurrently access the disk per index. This setting
+will allow `max_thread_count + 2` threads to operate on the disk at one time, so
+a setting of `1` will allow three threads.
 
 For SSDs, you can ignore this setting.  The default is
 `Math.min(3, Runtime.getRuntime().availableProcessors() / 2)`, which works well
 for SSD.
 
 Finally, you can increase `index.translog.flush_threshold_size` from the default
-512 MB to something larger, such as 1 GB.  This allows larger segments to accumulate
-in the translog before a flush occurs.  By letting larger segments build, you
-flush less often, and the larger segments merge less often.  All of this adds up
-to less disk I/O overhead and better indexing rates.  Of course, you will need
-the corresponding amount of heap memory free to accumulate the extra buffering
-space, so keep that in mind when adjusting this setting.
+512 MB to something larger, such as 1 GB. This allows larger segments to
+accumulate in the translog before a flush occurs. By letting larger segments
+build, you flush less often, and the larger segments merge less often. All of
+this adds up to less disk I/O overhead and better indexing rates. Of course, you
+will need the corresponding amount of heap memory free to accumulate the extra
+buffering space, so keep that in mind when adjusting this setting.
 
 ==== Other
 
 Finally, there are some other considerations to keep in mind:
 
 - If you don't need near real-time accuracy on your search results, consider
-dropping the `index.refresh_interval` of((("indexing", "performance tips", "other considerations")))((("refresh_interval setting"))) each index to `30s`.  If you are doing
-a large import, you can disable refreshes by setting this value to `-1` for the
-duration of the import.  Don't forget to reenable it when you are finished!
+dropping the `index.refresh_interval` of each index to `30s`. If you are doing a
+large import, you can disable refreshes by setting this value to `-1` for the
+duration of the import. Don't forget to reenable it when you are finished!
 
 - If you are doing a large bulk import, consider disabling replicas by setting
-`index.number_of_replicas: 0`.((("replicas, disabling during large bulk imports")))  When documents are replicated, the entire document
-is sent to the replica node and the indexing process is repeated verbatim.  This
-means each replica will perform the analysis, indexing, and potentially merging
-process.
+`index.number_of_replicas: 0`. When documents are replicated, the entire
+document is sent to the replica node and the indexing process is repeated
+verbatim. This means each replica will perform the analysis, indexing, and
+potentially merging process.
 +
-In contrast, if you index with zero replicas and then enable replicas when ingestion
-is finished, the recovery process is essentially a byte-for-byte network transfer.
-This is much more efficient than duplicating the indexing process.
+In contrast, if you index with zero replicas and then enable replicas when
+ingestion is finished, the recovery process is essentially a byte-for-byte
+network transfer. This is much more efficient than duplicating the indexing
+process.
 
 - If you don't have a natural ID for each document, use Elasticsearch's auto-ID
-functionality.((("id", "auto-ID functionality of Elasticsearch")))  It is optimized to avoid version lookups, since the autogenerated
+functionality. It is optimized to avoid version lookups, since the autogenerated
 ID is unique.
 
-- If you are using your own ID, try to pick an ID that is http://blog.mikemccandless.com/2014/05/choosing-fast-unique-identifier-uuid.html[friendly to Lucene]. ((("UUIDs (universally unique identifiers)"))) Examples include zero-padded
-sequential IDs, UUID-1, and nanotime; these IDs have consistent, sequential
-patterns that compress well.  In contrast, IDs such as UUID-4 are essentially
-random, which offer poor compression and slow down Lucene.
+- If you are using your own ID, try to pick an ID that is
+http://blog.mikemccandless.com/2014/05/choosing-fast-unique-identifier-uuid.html[friendly
+to Lucene]. ((("UUIDs (universally unique identifiers)"))) Examples include
+zero-padded sequential IDs, UUID-1, and nanotime; these IDs have consistent,
+sequential patterns that compress well. In contrast, IDs such as UUID-4 are
+essentially random, which offer poor compression and slow down Lucene.

--- a/520_Post_Deployment/35_delayed_shard_allocation.asciidoc
+++ b/520_Post_Deployment/35_delayed_shard_allocation.asciidoc
@@ -1,48 +1,49 @@
 
 === Delaying Shard Allocation
 
-As discussed way back in <<_scale_horizontally>>, Elasticsearch will automatically
-balance shards between your available nodes, both when new nodes are added and
-when existing nodes leave.
+As discussed way back in <<_scale_horizontally>>, Elasticsearch will
+automatically balance shards between your available nodes, both when new nodes
+are added and when existing nodes leave.
 
-Theoretically, this is the best thing to do.  We want to recover missing primaries
-by promoting replicas as soon as possible.  We also want to make sure resources
-are balanced evenly across the cluster to prevent hotspots.
+Theoretically, this is the best thing to do. We want to recover missing
+primaries by promoting replicas as soon as possible. We also want to make sure
+resources are balanced evenly across the cluster to prevent hotspots.
 
-In practice, however, immediately re-balancing can cause more problems than it solves.
-For example, consider this situation:
+In practice, however, immediately re-balancing can cause more problems than it
+solves. For example, consider this situation:
 
-1. Node 19 loses connectivity to your network (someone tripped on the power cable)
-2. Immediately, the master notices the node departure.  It determines
-what primary shards were on Node 19 and promotes the corresponding replicas around
+1. Node 19 loses connectivity to your network (someone tripped on the power
+cable)
+2. Immediately, the master notices the node departure. It determines what
+primary shards were on Node 19 and promotes the corresponding replicas around
 the cluster
-3. After replicas have been promoted to primary, the master begins issuing recovery
-commands to rebuild the now-missing replicas.  Nodes around the cluster fire up
-their NICs and start pumping shard data to each other in an attempt to get back
-to green health status
+3. After replicas have been promoted to primary, the master begins issuing
+recovery commands to rebuild the now-missing replicas. Nodes around the cluster
+fire up their NICs and start pumping shard data to each other in an attempt to
+get back to green health status
 4. This process will likely trigger a small cascade of shard movement, since the
-cluster is now unbalanced.  Unrelated shards will be moved between hosts to accomplish
-better balancing
+cluster is now unbalanced. Unrelated shards will be moved between hosts to
+accomplish better balancing
 
 Meanwhile, the hapless admin who kicked out the power cable plugs it back in.
-Node 19 reboots and rejoins the cluster.  Unfortunately, the node is informed that
-its existing data is now useless; the data being re-allocated elsewhere.
-So Node 19 deletes its local data and begins recovering a different
-set of shards from the cluster (which then causes a new minor re-balancing dance).
+Node 19 reboots and rejoins the cluster. Unfortunately, the node is informed
+that its existing data is now useless; the data being re-allocated elsewhere. So
+Node 19 deletes its local data and begins recovering a different set of shards
+from the cluster (which then causes a new minor re-balancing dance).
 
-If this all sounds needless and expensive, you're right.  It is, but _only when
-you know the node will be back soon_.  If Node 19 was truly gone, the above procedure
-is exactly what we want to happen.
+If this all sounds needless and expensive, you're right. It is, but _only when
+you know the node will be back soon_. If Node 19 was truly gone, the above
+procedure is exactly what we want to happen.
 
 To help address these transient outages, Elasticsearch has the ability to delay
-shard allocation.  This gives your cluster time to see if nodes will rejoin before
-starting the re-balancing dance.
+shard allocation. This gives your cluster time to see if nodes will rejoin
+before starting the re-balancing dance.
 
 ==== Changing the default delay
 
-By default, the cluster will wait one minute to see if the node will rejoin.  If
-the node rejoins before the timer expires, the rejoining node will use its existing
-shards and no shard allocation occurs.
+By default, the cluster will wait one minute to see if the node will rejoin. If
+the node rejoins before the timer expires, the rejoining node will use its
+existing shards and no shard allocation occurs.
 
 This default time can be changed either globally, or on a per-index basis, by
 configuring the `delayed_timeout` setting:
@@ -56,31 +57,31 @@ PUT /_all/_settings <1>
   }
 }
 ----
-<1> By using the `_all` index name, we can apply this setting to all indices
-in the cluster
+<1> By using the `_all` index name, we can apply this setting to all indices in
+the cluster
 <2> The default time is changed to 5 minutes
 
-The setting is dynamic and can be changed at runtime.  If you would like shards to
-allocate immediately instead of waiting, you can set `delayed_timeout: 0`.
+The setting is dynamic and can be changed at runtime. If you would like shards
+to allocate immediately instead of waiting, you can set `delayed_timeout: 0`.
 
-NOTE: Delayed allocation won't prevent replicas from being promoted to primaries.
-The cluster will still perform promotions as necessary to get the cluster back to
-`yellow` status.  The allocation of the now-missing replicas will be the only process
-that is delayed
+NOTE: Delayed allocation won't prevent replicas from being promoted to
+primaries. The cluster will still perform promotions as necessary to get the
+cluster back to `yellow` status. The allocation of the now-missing replicas will
+be the only process that is delayed
 
 ==== Auto-cancellation of shard relocation
 
-What happens if the node comes back _after_ the timeout expires, but before
-the cluster has finished moving shards around?  In this case, Elasticsearch will
-check to see if the on-disk data matches the current "live" data in the primary shard.
-If the two shards are identical -- meaning there have been no new documents, updates
-or deletes -- the master will cancel the on-going rebalancing and restore the
-on-disk data.
+What happens if the node comes back _after_ the timeout expires, but before the
+cluster has finished moving shards around? In this case, Elasticsearch will
+check to see if the on-disk data matches the current "live" data in the primary
+shard. If the two shards are identical -- meaning there have been no new
+documents, updates or deletes -- the master will cancel the on-going rebalancing
+and restore the on-disk data.
 
-This is done since recovery of on-disk data will always be faster
-than transferring over the network, and since we can guarantee the shards are identical,
-the process is a win-win.
+This is done since recovery of on-disk data will always be faster than
+transferring over the network, and since we can guarantee the shards are
+identical, the process is a win-win.
 
 If the shards have diverged (e.g. new documents have been indexed since the node
-went down), the recovery process will continue as normal.  The rejoining node
+went down), the recovery process will continue as normal. The rejoining node
 will delete it's local, out-dated shards and obtain a new set.

--- a/520_Post_Deployment/40_rolling_restart.asciidoc
+++ b/520_Post_Deployment/40_rolling_restart.asciidoc
@@ -3,34 +3,35 @@
 
 There will come a time when you need to perform a rolling restart of your
 cluster--keeping the cluster online and operational, but taking nodes offline
-one at a time.((("rolling restart of your cluster")))((("clusters", "rolling restarts")))((("post-deployment", "rolling restarts")))
+one at a time.
 
 The common reason is either an Elasticsearch version upgrade, or some kind of
-maintenance on the server itself (such as an OS update, or hardware).  Whatever the case,
-there is a particular method to perform a rolling restart.
+maintenance on the server itself (such as an OS update, or hardware). Whatever
+the case, there is a particular method to perform a rolling restart.
 
-By nature, Elasticsearch wants your data to be fully replicated and evenly balanced.
-If you shut down a single node for maintenance, the cluster will
-immediately recognize the loss of a node and begin rebalancing.  This can be irritating
-if you know the node maintenance is short term, since the rebalancing of
-very large shards can take some time (think of trying to replicate 1TB--even
+By nature, Elasticsearch wants your data to be fully replicated and evenly
+balanced. If you shut down a single node for maintenance, the cluster will
+immediately recognize the loss of a node and begin rebalancing. This can be
+irritating if you know the node maintenance is short term, since the rebalancing
+of very large shards can take some time (think of trying to replicate 1TB--even
 on fast networks this is nontrivial).
 
-What we want to do is tell Elasticsearch to hold off on rebalancing, because
-we have more knowledge about the state of the cluster due to external factors.
-The procedure is as follows:
+What we want to do is tell Elasticsearch to hold off on rebalancing, because we
+have more knowledge about the state of the cluster due to external factors. The
+procedure is as follows:
 
-1. If possible, stop indexing new data and perform a synced flush.  This is not always possible, but will
-help speed up recovery time.
-A synced flush request is a “best effort” operation. It will fail if there are any pending indexing operations, but it is safe to reissue the request multiple times if necessary.
+1. If possible, stop indexing new data and perform a synced flush. This is not
+always possible, but will help speed up recovery time. A synced flush request is
+a “best effort” operation. It will fail if there are any pending indexing
+operations, but it is safe to reissue the request multiple times if necessary.
 +
 [source,js]
 ----
 POST /_flush/synced
 ----
-2. Disable shard allocation.  This prevents Elasticsearch from rebalancing
-missing shards until you tell it otherwise.  If you know the maintenance window will be
-short, this is a good idea.  You can disable allocation as follows:
+2. Disable shard allocation. This prevents Elasticsearch from rebalancing
+missing shards until you tell it otherwise. If you know the maintenance window
+will be short, this is a good idea. You can disable allocation as follows:
 +
 [source,js]
 ----
@@ -57,12 +58,11 @@ PUT /_cluster/settings
 }
 ----
 +
-Shard rebalancing may take some time.  Wait until the cluster has returned
-to status `green` before continuing.
+Shard rebalancing may take some time. Wait until the cluster has returned to
+status `green` before continuing.
 
 7. Repeat steps 2 through 6 for the rest of your nodes.
 
-8. At this point you are safe to resume indexing (if you had previously stopped),
-but waiting until the cluster is fully balanced before resuming indexing will help
-to speed up the process.
-
+8. At this point you are safe to resume indexing (if you had previously
+stopped), but waiting until the cluster is fully balanced before resuming
+indexing will help to speed up the process.

--- a/520_Post_Deployment/50_backup.asciidoc
+++ b/520_Post_Deployment/50_backup.asciidoc
@@ -2,19 +2,19 @@
 === Backing Up Your Cluster
 
 As with any software that stores data, it is important to routinely back up your
-data. ((("clusters", "backing up")))((("post-deployment", "backing up your cluster")))((("backing up your cluster"))) Elasticsearch replicas provide high availability during runtime; they allow
-you to tolerate sporadic node loss without an interruption of service.
+data. Elasticsearch replicas provide high availability during runtime; they
+allow you to tolerate sporadic node loss without an interruption of service.
 
-Replicas do not provide protection from catastrophic failure, however.  For that,
+Replicas do not provide protection from catastrophic failure, however. For that,
 you need a real backup of your cluster--a complete copy in case something goes
 wrong.
 
-To back up your cluster, you can use the `snapshot` API.((("snapshot-restore API")))  This will take the current
-state and data in your cluster and save it to a shared repository.  This
-backup process is "smart."  Your first snapshot will be a complete copy of data,
+To back up your cluster, you can use the `snapshot` API. This will take the
+current state and data in your cluster and save it to a shared repository. This
+backup process is "smart." Your first snapshot will be a complete copy of data,
 but all subsequent snapshots will save the _delta_ between the existing
-snapshots and the new data.  Data is incrementally added and deleted as you snapshot
-data over time.  This means subsequent backups will be substantially
+snapshots and the new data. Data is incrementally added and deleted as you
+snapshot data over time. This means subsequent backups will be substantially
 faster since they are transmitting far less data.
 
 To use this functionality, you must first create a repository to save data.
@@ -27,7 +27,7 @@ There are several repository types that you may choose from:
 
 ==== Creating the Repository
 
-Let's set up a shared ((("backing up your cluster", "creating the repository")))((("filesystem repository")))filesystem repository:
+Let's set up a shared filesystem repository:
 
 [source,js]
 ----
@@ -46,18 +46,18 @@ PUT _snapshot/my_backup <1>
 NOTE: The shared filesystem path must be accessible from all nodes in your
 cluster!
 
-This will create the repository and required metadata at the mount point.  There
+This will create the repository and required metadata at the mount point. There
 are also some other options that you may want to configure, depending on the
 performance profile of your nodes, network, and repository location:
 
 `max_snapshot_bytes_per_sec`::
-    When snapshotting data into the repo, this controls
-the throttling of that process.  The default is `20mb` per second.
+    When snapshotting data into the repo, this controls the throttling of that
+process. The default is `20mb` per second.
 
 `max_restore_bytes_per_sec`::
-When restoring data from the repo, this controls
-how much the restore is throttled so that your network is not saturated.  The
-default is `20mb` per second.
+    When restoring data from the repo, this controls how much the restore is
+throttled so that your network is not saturated. The default is `20mb` per
+second.
 
 Let's assume we have a very fast network and are OK with extra traffic, so we
 can increase the defaults:
@@ -74,16 +74,16 @@ POST _snapshot/my_backup/ <1>
     }
 }
 ----
-<1> Note that we are using a `POST` instead of `PUT`.  This will update the settings
-of the existing repository.
+<1> Note that we are using a `POST` instead of `PUT`. This will update the
+settings of the existing repository.
 <2> Then add our new settings.
 
 ==== Snapshotting All Open Indices
 
-A repository can contain multiple snapshots.((("indices", "open, snapshots on")))((("backing up your cluster", "snapshots on all open indexes")))  Each snapshot is associated with a
-certain set of indices (for example, all indices, some subset, or a single index).  When
-creating a snapshot, you specify which indices you are interested in and
-give the snapshot a unique name.
+A repository can contain multiple snapshots. Each snapshot is associated with a
+certain set of indices (for example, all indices, some subset, or a single
+index). When creating a snapshot, you specify which indices you are interested
+in and give the snapshot a unique name.
 
 Let's start with the most basic snapshot command:
 
@@ -93,33 +93,34 @@ PUT _snapshot/my_backup/snapshot_1
 ----
 
 This will back up all open indices into a snapshot named `snapshot_1`, under the
-`my_backup` repository.  This call will return immediately, and the snapshot will
+`my_backup` repository. This call will return immediately, and the snapshot will
 proceed in the background.
 
 [TIP]
 ==================================================
 
-Usually you'll want your snapshots to proceed as a background process, but occasionally
-you may want to wait for completion in your script.  This can be accomplished by
-adding a `wait_for_completion` flag:
+Usually you'll want your snapshots to proceed as a background process, but
+occasionally you may want to wait for completion in your script. This can be
+accomplished by adding a `wait_for_completion` flag:
 
 [source,js]
 ----
 PUT _snapshot/my_backup/snapshot_1?wait_for_completion=true
 ----
 
-This will block the call until the snapshot has completed.  Note that large snapshots
-may take a long time to return!
+This will block the call until the snapshot has completed. Note that large
+snapshots may take a long time to return!
 
 ==================================================
 
 ==== Snapshotting Particular Indices
 
-The default behavior is to back up all open indices.((("indices", "snapshotting particular")))((("backing up your cluster", "snapshotting particular indices")))  But say you are using Marvel,
-and don't really want to back up all the diagnostic `.marvel` indices.  You
-just don't have enough space to back up everything.
+The default behavior is to back up all open indices. But say you are using
+Marvel, and don't really want to back up all the diagnostic `.marvel` indices.
+You just don't have enough space to back up everything.
 
-In that case, you can specify which indices to back up when snapshotting your cluster:
+In that case, you can specify which indices to back up when snapshotting your
+cluster:
 
 [source,js]
 ----
@@ -133,12 +134,12 @@ This snapshot command will now back up only `index1` and `index2`.
 
 ==== Listing Information About Snapshots
 
-Once you start accumulating snapshots in your repository, you may forget the details((("backing up your cluster", "listing information about snapshots")))
-relating to each--particularly when the snapshots are named based on time
-demarcations (for example, `backup_2014_10_28`).
+Once you start accumulating snapshots in your repository, you may forget the
+details relating to each--particularly when the snapshots are named based on
+time demarcations (for example, `backup_2014_10_28`).
 
-To obtain information about a single snapshot, simply issue a `GET` request against
-the repo and snapshot name:
+To obtain information about a single snapshot, simply issue a `GET` request
+against the repo and snapshot name:
 
 [source,js]
 ----
@@ -176,8 +177,8 @@ the snapshot:
 }
 ----
 
-For a complete listing of all snapshots in a repository, use the `_all` placeholder
-instead of a snapshot name:
+For a complete listing of all snapshots in a repository, use the `_all`
+placeholder instead of a snapshot name:
 
 [source,js]
 ----
@@ -186,7 +187,7 @@ GET _snapshot/my_backup/_all
 
 ==== Deleting Snapshots
 
-Finally, we need a command to delete old snapshots that ((("backing up your cluster", "deleting old snapshots")))are no longer useful.
+Finally, we need a command to delete old snapshots that are no longer useful.
 This is simply a `DELETE` HTTP call to the repo/snapshot name:
 
 [source,js]
@@ -195,10 +196,10 @@ DELETE _snapshot/my_backup/snapshot_2
 ----
 
 It is important to use the API to delete snapshots, and not some other mechanism
-(such as deleting by hand, or using automated cleanup tools on S3).  Because snapshots are
-incremental, it is possible that many snapshots are relying on old segments.
-The `delete` API understands what data is still in use by more recent snapshots,
-and will delete only unused segments.
+(such as deleting by hand, or using automated cleanup tools on S3). Because
+snapshots are incremental, it is possible that many snapshots are relying on old
+segments. The `delete` API understands what data is still in use by more recent
+snapshots, and will delete only unused segments.
 
 If you do a manual file delete, however, you are at risk of seriously corrupting
 your backups because you are deleting data that is still in use.
@@ -207,11 +208,12 @@ your backups because you are deleting data that is still in use.
 ==== Monitoring Snapshot Progress
 
 The `wait_for_completion` flag provides a rudimentary form of monitoring, but
-really isn't sufficient when snapshotting or restoring even moderately sized clusters.
+really isn't sufficient when snapshotting or restoring even moderately sized
+clusters.
 
-Two other APIs will give you more-detailed status about the
-state of the snapshotting.  First you can execute a `GET` to the snapshot ID,
-just as we did earlier get information about a particular snapshot:
+Two other APIs will give you more-detailed status about the state of the
+snapshotting. First you can execute a `GET` to the snapshot ID, just as we did
+earlier get information about a particular snapshot:
 
 [source,js]
 ----
@@ -219,10 +221,10 @@ GET _snapshot/my_backup/snapshot_3
 ----
 
 If the snapshot is still in progress when you call this, you'll see information
-about when it was started, how long it has been running, and so forth.  Note, however,
-that this API uses the same threadpool as the snapshot mechanism.  If you are
-snapshotting very large shards, the time between status updates can be quite large,
-since the API is competing for the same threadpool resources.
+about when it was started, how long it has been running, and so forth. Note,
+however, that this API uses the same threadpool as the snapshot mechanism. If
+you are snapshotting very large shards, the time between status updates can be
+quite large, since the API is competing for the same threadpool resources.
 
 A better option is to poll the `_status` API:
 
@@ -291,35 +293,38 @@ statistics:
                   ...
 ----
 <1> A snapshot that is currently running will show `IN_PROGRESS` as its status.
-<2> This particular snapshot has one shard still transferring (the other four have already completed).
+<2> This particular snapshot has one shard still transferring (the other four
+have already completed).
 
-The response includes the overall status of the snapshot, but also drills down into
-per-index and per-shard statistics.  This gives you an incredibly detailed view
-of how the snapshot is progressing.  Shards can be in various states of completion:
+The response includes the overall status of the snapshot, but also drills down
+into per-index and per-shard statistics. This gives you an incredibly detailed
+view of how the snapshot is progressing. Shards can be in various states of
+completion:
 
 `INITIALIZING`::
-    The shard is checking with the cluster state to see whether it can
-be snapshotted.  This is usually very fast.
+    The shard is checking with the cluster state to see whether it can be
+snapshotted. This is usually very fast.
 
 `STARTED`::
     Data is being transferred to the repository.
-    
+
 `FINALIZING`::
     Data transfer is complete; the shard is now sending snapshot metadata.
-    
+
 `DONE`::
     Snapshot complete!
-    
+
 `FAILED`::
-    An error was encountered during the snapshot process, and this shard/index/snapshot
-could not be completed.  Check your logs for more information.
+    An error was encountered during the snapshot process, and this
+shard/index/snapshot could not be completed. Check your logs for more
+information.
 
 
 ==== Canceling a Snapshot
 
-Finally, you may want to cancel a snapshot or restore.((("backing up your cluster", "canceling a snapshot")))  Since these are long-running
-processes, a typo or mistake when executing the operation could take a long time to
-resolve--and use up valuable resources at the same time.
+Finally, you may want to cancel a snapshot or restore. Since these are
+long-running processes, a typo or mistake when executing the operation could
+take a long time to resolve--and use up valuable resources at the same time.
 
 To cancel a snapshot, simply delete the snapshot while it is in progress:
 
@@ -330,5 +335,3 @@ DELETE _snapshot/my_backup/snapshot_3
 
 This will halt the snapshot process. Then proceed to delete the half-completed
 snapshot from the repository.
-
-

--- a/520_Post_Deployment/60_restore.asciidoc
+++ b/520_Post_Deployment/60_restore.asciidoc
@@ -1,23 +1,23 @@
 
 === Restoring from a Snapshot
 
-Once you've backed up some data, restoring it is easy: simply add `_restore`
-to the ID of((("post-deployment", "restoring from a snapshot")))((("restoring from a snapshot"))) the snapshot you wish to restore into your cluster:
+Once you've backed up some data, restoring it is easy: simply add `_restore` to
+the ID of the snapshot you wish to restore into your cluster:
 
 [source,js]
 ----
 POST _snapshot/my_backup/snapshot_1/_restore
 ----
 
-The default behavior is to restore all indices that exist in that snapshot.
-If `snapshot_1` contains five indices, all five will be restored into
-our cluster. ((("indices", "restoring from a snapshot"))) As with the `snapshot` API, it is possible to select which indices
-we want to restore.
+The default behavior is to restore all indices that exist in that snapshot. If
+`snapshot_1` contains five indices, all five will be restored into our cluster.
+As with the `snapshot` API, it is possible to select which indices we want to
+restore.
 
-There are also additional options for renaming indices.  This allows you to
-match index names with a pattern, and then provide a new name during the restore process.
-This is useful if you want to restore old data to verify its contents, or perform
-some other processing, without replacing existing data.  Let's restore
+There are also additional options for renaming indices. This allows you to match
+index names with a pattern, and then provide a new name during the restore
+process. This is useful if you want to restore old data to verify its contents,
+or perform some other processing, without replacing existing data. Let's restore
 a single index from the snapshot and provide a replacement name:
 
 [source,js]
@@ -34,15 +34,16 @@ snapshot.
 <2> Find any indices being restored that match the provided pattern.
 <3> Then rename them with the replacement pattern.
 
-This will restore `index_1` into your cluster, but rename it to `restored_index_1`.
+This will restore `index_1` into your cluster, but rename it to
+`restored_index_1`.
 
 [TIP]
 ==================================================
 
 Similar to snapshotting, the `restore` command will return immediately, and the
-restoration process will happen in the background.  If you would prefer your HTTP
-call to block until the restore is finished, simply add the `wait_for_completion`
-flag:
+restoration process will happen in the background. If you would prefer your HTTP
+call to block until the restore is finished, simply add the
+`wait_for_completion` flag:
 
 [source,js]
 ----
@@ -55,8 +56,8 @@ POST _snapshot/my_backup/snapshot_1/_restore?wait_for_completion=true
 ==== Monitoring Restore Operations
 
 The restoration of data from a repository piggybacks on the existing recovery
-mechanisms already in place in Elasticsearch.((("restoring from a snapshot", "monitoring restore operations")))  Internally, recovering shards
-from a repository is identical to recovering from another node.
+mechanisms already in place in Elasticsearch. Internally, recovering shards from
+a repository is identical to recovering from another node.
 
 If you wish to monitor the progress of a restore, you can use the `recovery`
 API.  This is a general-purpose API that shows the status of shards moving around
@@ -69,8 +70,8 @@ The API can be invoked for the specific indices that you are recovering:
 GET restored_index_3/_recovery
 ----
 
-Or for all indices in your cluster, which may include other shards moving around,
-unrelated to your restore process:
+Or for all indices in your cluster, which may include other shards moving
+around, unrelated to your restore process:
 
 [source,js]
 ----
@@ -134,18 +135,18 @@ depending on the activity of your cluster!):
 recovered from a snapshot.
 <2> The `source` hash describes the particular snapshot and repository that is
 being recovered from.
-<3> The `percent` field gives you an idea about the status of the recovery.
-This particular shard has recovered 94% of the files so far; it is almost complete.
+<3> The `percent` field gives you an idea about the status of the recovery. This
+particular shard has recovered 94% of the files so far; it is almost complete.
 
-The output will list all indices currently undergoing a recovery, and then
-list all shards in each of those indices.  Each shard will have stats
-about start/stop time, duration, recover percentage, bytes transferred, and more.
+The output will list all indices currently undergoing a recovery, and then list
+all shards in each of those indices. Each shard will have stats about start/stop
+time, duration, recover percentage, bytes transferred, and more.
 
 ==== Canceling a Restore
 
-To cancel a restore, you need to delete the indices being restored.((("restoring from a snapshot", "canceling a restore")))  Because
-a restore process is really just shard recovery, issuing a `delete-index` API
-alters the cluster state, which will in turn halt recovery.  For example:
+To cancel a restore, you need to delete the indices being restored. Because a
+restore process is really just shard recovery, issuing a `delete-index` API
+alters the cluster state, which will in turn halt recovery. For example:
 
 [source,js]
 ----
@@ -155,7 +156,3 @@ DELETE /restored_index_3
 If `restored_index_3` was actively being restored, this delete command would
 halt the restoration as well as deleting any data that had already been restored
 into the cluster.
-
-
-
-

--- a/520_Post_Deployment/70_conclusion.asciidoc
+++ b/520_Post_Deployment/70_conclusion.asciidoc
@@ -2,23 +2,24 @@
 === Clusters Are Living, Breathing Creatures
 
 Once you get a cluster into production, you'll find that it takes on a life of its
-own.  ((("clusters", "maintaining")))((("post-deployment", "clusters, rolling restarts and upgrades")))Elasticsearch works hard to make clusters self-sufficient and _just work_.
-But a cluster still requires routine care and feeding, such as routine backups 
+own. Elasticsearch works hard to make clusters self-sufficient and _just work_.
+But a cluster still requires routine care and feeding, such as routine backups
 and upgrades.
 
-Elasticsearch releases new versions with bug fixes and performance enhancements at 
-a very fast pace, and it is always a good idea to keep your cluster current.
-Similarly, Lucene continues to find new and exciting bugs in the JVM itself, which
-means you should always try to keep your JVM up-to-date.
+Elasticsearch releases new versions with bug fixes and performance enhancements
+at a very fast pace, and it is always a good idea to keep your cluster current.
+Similarly, Lucene continues to find new and exciting bugs in the JVM itself,
+which means you should always try to keep your JVM up-to-date.
 
-This means it is a good idea to have a standardized, routine way to perform rolling
-restarts and upgrades in your cluster.  Upgrading should be a routine process, 
-rather than a once-yearly fiasco that requires countless hours of precise planning.
+This means it is a good idea to have a standardized, routine way to perform
+rolling restarts and upgrades in your cluster. Upgrading should be a routine
+process, rather than a once-yearly fiasco that requires countless hours of
+precise planning.
 
-Similarly, it is important to have disaster recovery plans in place.  Take frequent
-snapshots of your cluster--and periodically _test_ those snapshots by performing
-a real recovery!  It is all too common for organizations to make routine backups but
-never test their recovery strategy.  Often you'll find a glaring deficiency
-the first time you perform a real recovery (such as users being unaware of which
-drive to mount).  It's better to work these bugs out of your process with 
-routine testing, rather than at 3 a.m. when there is a crisis.
+Similarly, it is important to have disaster recovery plans in place. Take
+frequent snapshots of your cluster--and periodically _test_ those snapshots by
+performing a real recovery! It is all too common for organizations to make
+routine backups but never test their recovery strategy. Often you'll find a
+glaring deficiency the first time you perform a real recovery (such as users
+being unaware of which drive to mount). It's better to work these bugs out of
+your process with routine testing, rather than at 3 a.m. when there is a crisis.


### PR DESCRIPTION
Apologies for the size/tediousness of this, but I wanted to get this mechanical sort of thing out of the way before doing more substantive refactoring. There were a number of glossary annotations, lots of doubling up on spaces after periods, and overlong lines that contributed to a large diff.

This PR does not include any actual content edits. Wheat and chaff, signal and noise, etc.
