### PR TITLE
Update Getting Started with Languages:

### DIFF
--- a/200_Language_intro/00_Intro.asciidoc
+++ b/200_Language_intro/00_Intro.asciidoc
@@ -2,16 +2,10 @@
 == Getting Started with Languages
 
 Elasticsearch ships with a collection of language analyzers that provide
-good, basic, out-of-the-box ((("language analyzers")))((("languages", "getting started with")))support for many of the world's most common
-languages:
+good, basic, https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-lang-analyzer.html[out-of-the-box support]
+for many of the world's most common languages.
 
-Arabic, Armenian, Basque, Brazilian, Bulgarian, Catalan, Chinese,
-Czech, Danish, Dutch, English, Finnish, French, Galician, German, Greek,
-Hindi, Hungarian, Indonesian, Irish, Italian, Japanese, Korean, Kurdish, 
-Norwegian, Persian, Portuguese, Romanian, Russian, Spanish, Swedish, 
-Turkish, and Thai.
-
-These analyzers typically((("language analyzers", "roles performed by"))) perform four roles:
+These analyzers typically perform four roles:
 
 * Tokenize text into individual words:
 +
@@ -30,19 +24,18 @@ These analyzers typically((("language analyzers", "roles performed by"))) perfor
 `foxes` -> `fox`
 
 Each analyzer may also apply other transformations specific to its language in
-order to make words from that((("language analyzers", "other transformations specific to the language"))) language more searchable:
+order to make words from that language more searchable:
 
-* The `english` analyzer ((("english analyzer")))removes the possessive `'s`:
+* The `english` analyzer removes the possessive `'s`:
 +
 `John's` -> `john`
 
-* The `french` analyzer ((("french analyzer")))removes _elisions_ like `l'` and `qu'` and
+* The `french` analyzer removes _elisions_ like `l'` and `qu'` and
   _diacritics_ like `¨` or `^`:
 +
 `l'église` -> `eglis`
 
-* The `german` analyzer normalizes((("german analyzer"))) terms, replacing `ä` and `ae` with `a`, or
+* The `german` analyzer normalizes terms, replacing `ä` and `ae` with `a`, or
   `ß` with `ss`, among others:
 +
 `äußerst` -> `ausserst`
-

--- a/200_Language_intro/10_Using.asciidoc
+++ b/200_Language_intro/10_Using.asciidoc
@@ -2,7 +2,7 @@
 === Using Language Analyzers
 
 The built-in language analyzers are available globally and don't need to be
-configured before being used.((("language analyzers", "using")))  They can be specified directly in the field
+configured before being used.  They can be specified directly in the field
 mapping:
 
 [source,js]
@@ -13,7 +13,7 @@ PUT /my_index
     "blog": {
       "properties": {
         "title": {
-          "type":     "string",
+          "type":     "text",
           "analyzer": "english" <1>
         }
       }
@@ -21,18 +21,25 @@ PUT /my_index
   }
 }
 --------------------------------------------------
+// CONSOLE
+
 <1> The `title` field will use the `english` analyzer instead of the default
     `standard` analyzer.
 
-Of course, by passing ((("english analyzer", "information lost with")))text through the `english` analyzer, we lose
-information:
+Of course, by passing text through the `english` analyzer, we lose information:
 
 [source,js]
 --------------------------------------------------
-GET /my_index/_analyze?field=title <1>
-I'm not happy about the foxes
+GET /my_index/_analyze
+{
+  "field": "title"
+  "text": "I'm not happy about the foxes" <1>
+}
 --------------------------------------------------
-<1> Emits token: `i'm`, `happi`, `about`, `fox`
+// CONSOLE
+// TEST[continued]
+
+<1> Emits the tokens: `i'm`, `happi`, `about`, `fox`
 
 We can't tell if the document mentions one `fox` or many  `foxes`; the word
 `not` is a stopword and is removed, so we can't tell whether the document is
@@ -41,7 +48,7 @@ recall as we can match more loosely, but we have reduced our ability to rank
 documents accurately.
 
 To get the best of both worlds, we can use <<multi-fields,multifields>> to
-index the `title` field twice: once((("multifields", "using to index a field with two different analyzers"))) with the `english` analyzer and once with
+index the `title` field twice: once with the `english` analyzer and once with
 the `standard` analyzer:
 
 [source,js]
@@ -52,10 +59,10 @@ PUT /my_index
     "blog": {
       "properties": {
         "title": { <1>
-          "type": "string",
+          "type": "text",
           "fields": {
             "english": { <2>
-              "type":     "string",
+              "type":     "text",
               "analyzer": "english"
             }
           }
@@ -65,6 +72,8 @@ PUT /my_index
   }
 }
 --------------------------------------------------
+// CONSOLE
+
 <1> The main `title` field uses the `standard` analyzer.
 <2> The `title.english` subfield uses the `english` analyzer.
 
@@ -90,12 +99,13 @@ GET /_search
   }
 }
 --------------------------------------------------
+// CONSOLE
+// TEST[continued]
+
 <1> Use the <<most-fields,`most_fields`>> query type to match the
     same text in as many fields as possible.
 
-Even ((("most fields queries")))though neither of our documents contain the word `foxes`,  both documents
-are returned as results thanks to the word stemming on the `title.english`
-field.  The second document is ranked as more relevant, because the word `not`
-matches on the `title` field.
-
-
+Even though neither of our documents contain the
+word `foxes`,  both documents are returned as results thanks to the word
+stemming on the `title.english` field.  The second document is ranked as more
+relevant, because the word `not` matches on the `title` field.

--- a/200_Language_intro/20_Configuring.asciidoc
+++ b/200_Language_intro/20_Configuring.asciidoc
@@ -2,13 +2,13 @@
 === Configuring Language Analyzers
 
 While the language analyzers can be used out of the box without any
-configuration, most of them ((("english analyzer", "configuring")))((("language analyzers", "configuring")))do allow you to control aspects of their
+configuration, most of them do allow you to control aspects of their
 behavior, specifically:
 
 [[stem-exclusion]]
 Stem-word exclusion::
 +
-Imagine, for instance, that users searching for((("language analyzers", "configuring", "stem word exclusion")))((("stemming words", "stem word exclusion, configuring"))) the ``World Health
+Imagine, for instance, that users searching for the ``World Health
 Organization'' are instead getting results for ``organ health.'' The reason
 for this confusion is that both ``organ'' and ``organization'' are stemmed to
 the same root word: `organ`. Often this isn't a problem, but in this
@@ -18,7 +18,7 @@ stemmed.
 
 Custom stopwords::
 
-The default list of stopwords((("stopwords", "configuring for language analyzers"))) used in English are as follows:
+The default list of stopwords used in English are as follows:
 +
     a, an, and, are, as, at, be, but, by, for, if, in, into, is, it,
     no, not, of, on, or, such, that, the, their, then, there, these,
@@ -54,13 +54,17 @@ PUT /my_index
   }
 }
 
-GET /my_index/_analyze?analyzer=my_english <3>
-The World Health Organization does not sell organs.
+GET /my_index/_analyze
+{
+  "analyzer": "my_english", <3>
+  "text": "The World Health Organization does not sell organs."
+}
 --------------------------------------------------
+// CONSOLE
+
 <1> Prevents `organization` and `organizations` from being stemmed
 <2> Specifies a custom list of stopwords
-<3> Emits tokens `world`, `health`, `organization`, `does`, `not`, `sell`, `organ`
+<3> Emits tokens `world`, `health`, `organization`, `doe`, `not`, `sell`, `organ`
 
 We discuss stemming and stopwords in much more detail in <<stemming>> and
 <<stopwords>>, respectively.
-

--- a/200_Language_intro/30_Language_pitfalls.asciidoc
+++ b/200_Language_intro/30_Language_pitfalls.asciidoc
@@ -1,9 +1,9 @@
 [[language-pitfalls]]
 === Pitfalls of Mixing Languages
 
-If you have to deal with only a single language,((("languages", "mixing, pitfalls of"))) count yourself lucky.
+If you have to deal with only a single language, count yourself lucky.
 Finding the right strategy for handling documents written in several languages
-can be challenging.((("indexing", "mixed languages, pitfalls of")))
+can be challenging.
 
 ==== At Index Time
 
@@ -21,11 +21,11 @@ separate.  Mixing languages in the same inverted index can be problematic.
 ===== Incorrect stemming
 
 The stemming rules for German are different from those for English, French,
-Swedish, and so on.((("stemming words", "incorrect stemming in multilingual documents"))) Applying the same stemming rules to different languages
+Swedish, and so on. Applying the same stemming rules to different languages
 will result in some words being stemmed correctly, some  incorrectly, and some
-not being stemmed at all. It may even result in words from different languages with different meanings
-being stemmed to the same root word, conflating their meanings and producing
-confusing search results for the user.
+not being stemmed at all. It may even result in words from different languages
+with different meanings being stemmed to the same root word, conflating their
+meanings and producing confusing search results for the user.
 
 Applying multiple stemmers in turn to the same text is likely to result in
 rubbish, as the next stemmer may try to stem an already stemmed word,
@@ -49,7 +49,7 @@ text.
 ===== Incorrect inverse document frequencies
 
 In <<relevance-intro>>, we explained that the more frequently a term appears
-in a collection of documents, the less weight that term has.((("inverse document frequency", "incorrect, in multilingual documents")))  For accurate
+in a collection of documents, the less weight that term has.  For accurate
 relevance calculations, you need accurate term-frequency statistics.
 
 A short snippet of German appearing in predominantly English text would give
@@ -59,11 +59,11 @@ snippets now have much less weight.
 
 ==== At Query Time
 
-It is not sufficient just to think about your documents, though.((("queries", "mixed languages and")))  You also need
-to think about how your users will query those documents.  Often you will be able
-to identify the main language of the user either from the language of that user's chosen
-interface (for example, `mysite.de` versus `mysite.fr`) or from the
-http://www.w3.org/International/questions/qa-lang-priorities.en.php[`accept-language`]
+It is not sufficient just to think about your documents, though.  You also need
+to think about how your users will query those documents.  Often you will be
+able to identify the main language of the user either from the language of that
+user's chosen interface (for example, `mysite.de` versus `mysite.fr`) or from
+the http://www.w3.org/International/questions/qa-lang-priorities.en.php[`accept-language`]
 HTTP header from the user's browser.
 
 User searches also come in three main varieties:
@@ -72,7 +72,8 @@ User searches also come in three main varieties:
 * Users search for words in a different language, but expect results in
   their main language.
 * Users search for words in a different language, and expect results in
-  that language (for example, a bilingual person, or a foreign visitor in a web cafe).
+  that language (for example, a bilingual person, or a foreign visitor in a web
+  cafe).
 
 Depending on the type of data that you are searching, it may be appropriate to
 return results in a single language (for example, a user searching for products on
@@ -102,7 +103,7 @@ library from
 http://blog.mikemccandless.com/2013/08/a-new-version-of-compact-language.html[Mike McCandless],
 which uses the open source (http://www.apache.org/licenses/LICENSE-2.0[Apache License 2.0])
 https://code.google.com/p/cld2/[Compact Language Detector] (CLD) from Google.  It is
-small, fast, ((("Compact Language Detector (CLD)")))and accurate, and can detect 160+ languages from as little as two
+small, fast, and accurate, and can detect 160+ languages from as little as two
 sentences. It can even detect multiple languages within a single block of
 text. Bindings exist for several languages including Python, Perl, JavaScript,
 PHP, C#/.NET, and R.
@@ -113,4 +114,3 @@ Shorter amounts of text, such as search keywords, produce much less accurate
 results. In these cases, it may be preferable to take simple heuristics into
 account such as the country of origin, the user's selected language, and the
 HTTP `accept-language` headers.
-

--- a/200_Language_intro/40_One_language_per_doc.asciidoc
+++ b/200_Language_intro/40_One_language_per_doc.asciidoc
@@ -2,8 +2,8 @@
 === One Language per Document
 
 A single predominant language per document requires a relatively simple setup.
-Documents from different languages can be stored in separate indices&#x2014;`blogs-en`,
-`blogs-fr`, and so forth&#x2014;that use the same fields for each index, just
+Documents from different languages can be stored in separate indices -- `blogs-en`,
+`blogs-fr`, and so forth -- that use the same fields for each index, just
 with different analyzers:
 
 [source,js]

--- a/200_Language_intro/40_One_language_per_doc.asciidoc
+++ b/200_Language_intro/40_One_language_per_doc.asciidoc
@@ -1,10 +1,10 @@
 [[one-lang-docs]]
 === One Language per Document
 
-A single predominant language per document ((("languages", "one language per document")))((("indices", "documents in different languages")))requires a relatively simple setup.
+A single predominant language per document requires a relatively simple setup.
 Documents from different languages can be stored in separate indices&#x2014;`blogs-en`,
-`blogs-fr`, and so forth&#x2014;that use the same type and the same fields for each index,
-just with different analyzers:
+`blogs-fr`, and so forth&#x2014;that use the same fields for each index, just
+with different analyzers:
 
 [source,js]
 --------------------------------------------------
@@ -14,13 +14,18 @@ PUT /blogs-en
     "post": {
       "properties": {
         "title": {
-          "type": "string", <1>
+          "type": "text", <1>
           "fields": {
             "stemmed": {
-              "type":     "string",
+              "type": "string",
               "analyzer": "english" <2>
             }
-}}}}}}
+          }
+        }
+      }
+    }
+  }
+}
 
 PUT /blogs-fr
 {
@@ -28,14 +33,21 @@ PUT /blogs-fr
     "post": {
       "properties": {
         "title": {
-          "type": "string", <1>
+          "type": "text", <1>
           "fields": {
             "stemmed": {
-              "type":     "string",
+              "type": "text",
               "analyzer": "french" <2>
             }
-}}}}}}
+          }
+        }
+      }
+    }
+  }
+}
 --------------------------------------------------
+//CONSOLE
+
 <1> Both `blogs-en` and `blogs-fr` have a type called `post` that contains
     the field `title`.
 <2> The `title.stemmed` subfield uses a language-specific analyzer.
@@ -48,25 +60,34 @@ don't suffer from the term-frequency and stemming problems described in
 
 The documents of a single language can be queried independently, or queries
 can target multiple languages by querying multiple indices.  We can even
-specify a preference((("indices_boost parameter", "specifying preference for a specific language"))) for particular languages with the `indices_boost` parameter:
+specify a preference for particular languages with the `indices_boost` parameter:
 
 [source,js]
 --------------------------------------------------
+PUT /blogs-en/post/1
+{ "title": "That feeling of déjà vu" }
+
+PUT /blogs-fr/post/1
+{ "title": "Ce sentiment de déjà vu" }
+
 GET /blogs-*/post/_search <1>
 {
     "query": {
         "multi_match": {
             "query":   "deja vu",
-            "fields":  [ "title", "title.stemmed" ] <2>
+            "fields":  [ "title", "title.stemmed" ], <2>
             "type":    "most_fields"
         }
     },
-    "indices_boost": { <3>
-        "blogs-en": 3,
-        "blogs-fr": 2
-    }
+    "indices_boost": [ <3>
+      { "blogs-en": 3 },
+      { "blogs-fr": 2 }
+    ]
 }
 --------------------------------------------------
+// CONSOLE
+// TEST[continued]
+
 <1> This search is performed on any index beginning with `blogs-`.
 <2> The `title.stemmed` fields are queried using the analyzer
     specified in each index.
@@ -78,27 +99,11 @@ GET /blogs-*/post/_search <1>
 
 Of course, these documents may contain words or sentences in other languages,
 and these words are unlikely to be stemmed correctly.  With
-predominant-language documents, this is not usually a major problem.  The user will
-often search for the exact words--for instance, of a quotation from another
+predominant-language documents, this is not usually a major problem.  The user
+will often search for the exact words--for instance, of a quotation from another
 language--rather than for inflections of a word. Recall can be improved
 by using techniques explained in <<token-normalization>>.
 
 Perhaps some words like place names should be queryable in the predominant
 language and in the original language, such as _Munich_ and _München_.  These
 words are effectively synonyms, which we discuss in <<synonyms>>.
-
-.Don't Use Types for Languages
-*************************************************
-
-You may be tempted to use a separate type for each language,((("types", "not using for languages")))((("languages", "not using types for"))) instead of a
-separate index. For best results, you should avoid using types for this
-purpose.  As explained in <<mapping>>, fields from different types but with
-the same field name are indexed into the _same inverted index_.  This means
-that the term frequencies from each type (and thus each language) are mixed
-together.
-
-To ensure that the term frequencies of one language don't pollute those of
-another, either use a separate index for each language, or a separate field,
-as explained in the next section.
-
-*************************************************

--- a/200_Language_intro/50_One_language_per_field.asciidoc
+++ b/200_Language_intro/50_One_language_per_field.asciidoc
@@ -1,10 +1,11 @@
 [[one-lang-fields]]
 === One Language per Field
 
-For documents that represent entities like products, movies, or legal notices, it is common((("fields", "one language per field")))((("languages", "one language per field")))
-for the same text to be translated into several languages.  Although each translation
-could be represented in a single document in an index per language, another
-reasonable approach is to keep all translations in the same document:
+For documents that represent entities like products, movies, or legal notices,
+it is common for the same text to be translated into several languages. Although
+each translation could be represented in a single document in an index per
+language, another reasonable approach is to keep all translations in the same
+document:
 
 [source,js]
 --------------------------------------------------
@@ -29,29 +30,31 @@ PUT /movies
     "movie": {
       "properties": {
         "title": { <1>
-          "type":       "string"
+          "type": "text"
         },
         "title_br": { <2>
-            "type":     "string",
-            "analyzer": "brazilian"
+          "type": "text",
+          "analyzer": "brazilian"
         },
         "title_cz": { <2>
-            "type":     "string",
-            "analyzer": "czech"
+          "type": "text",
+          "analyzer": "czech"
         },
         "title_en": { <2>
-            "type":     "string",
-            "analyzer": "english"
+          "type": "text",
+          "analyzer": "english"
         },
         "title_es": { <2>
-            "type":     "string",
-            "analyzer": "spanish"
+          "type": "text",
+          "analyzer": "spanish"
         }
       }
     }
   }
 }
 --------------------------------------------------
+// CONSOLE
+
 <1> The `title` field contains the original title and uses the
     `standard` analyzer.
 <2> Each of the other fields uses the appropriate analyzer for
@@ -59,19 +62,31 @@ PUT /movies
 
 Like the _index-per-language_ approach, the _field-per-language_ approach
 maintains clean term frequencies. It is not quite as flexible as having
-separate indices.  Although it is easy to add a new field by using the <<updating-a-mapping,`update-mapping` API>>, those new fields may require new
-custom analyzers, which can only be set up at index creation time.  As a
-workaround, you can {ref}/indices-open-close.html[close] the index, add the new
-analyzers with the {ref}/indices-update-settings.html[`update-settings` API],
+separate indices.  Although it is easy to add a new field by using the <<updating-a-mapping,`update-mapping` API>>,
+those new fields may require new custom analyzers, which can only be set up at
+index creation time.  As a workaround, you can {ref}/indices-open-close.html[close]
+the index, add the new analyzers with the {ref}/indices-update-settings.html[`update-settings` API],
 then reopen the index, but closing the index means that it will require some
 downtime.
 
-The documents of a((("boosting", "query-time", "boosting a field"))) single language can be queried independently, or queries
+The documents of a single language can be queried independently, or queries
 can target multiple languages by querying multiple fields.  We can even
 specify a preference for particular languages by boosting that field:
 
 [source,js]
 --------------------------------------------------
+PUT /movies/movie/1
+{
+     "title":     "Fight club",
+     "title_br":  "Clube de Luta",
+     "title_cz":  "Klub rváčů",
+     "title_en":  "Fight club",
+     "title_es":  "El club de la lucha"
+}
+
+PUT /movies/movie/2
+{ "title": "Superhero Fight Club" }
+
 GET /movies/movie/_search
 {
     "query": {
@@ -83,7 +98,9 @@ GET /movies/movie/_search
     }
 }
 --------------------------------------------------
+// CONSOLE
+// TEST[continued]
+
 <1> This search queries any field beginning with `title` but
     boosts the `title_es` field by `2`.  All other fields have
     a neutral boost of `1`.
-

--- a/200_Language_intro/60_Mixed_language_fields.asciidoc
+++ b/200_Language_intro/60_Mixed_language_fields.asciidoc
@@ -2,7 +2,7 @@
 === Mixed-Language Fields
 
 Usually, documents that mix multiple languages in a single field come from
-sources beyond your control, such as((("languages", "mixed language fields")))((("fields", "mixed language"))) pages scraped from the Web:
+sources beyond your control, such as pages scraped from the Web:
 
 [source,js]
 --------------------------------------------------
@@ -17,7 +17,8 @@ Or rather, stemmers are language and script specific.  As discussed in
 <<different-scripts>>, if every language uses a different script, then
 stemmers can be combined.
 
-Assuming that your mix of languages uses the same script such as Latin, you have three choices available to you:
+Assuming that your mix of languages uses the same script such as Latin, you have
+three choices available to you:
 
 * Split into separate fields
 * Analyze multiple times
@@ -25,14 +26,14 @@ Assuming that your mix of languages uses the same script such as Latin, you have
 
 ==== Split into Separate Fields
 
-The Compact Language Detector ((("languages", "mixed language fields", "splitting into separate fields")))((("Compact Language Detector (CLD)")))mentioned in <<identifying-language>> can tell
+The Compact Language Detector mentioned in <<identifying-language>> can tell
 you which parts of the document are in which language.  You can split up the
 text based on language and use the same approach as was used in
 <<one-lang-fields>>.
 
 ==== Analyze Multiple Times
 
-If you primarily deal with a limited number of languages, ((("languages", "mixed language fields", "analyzing multiple times")))((("analyzers", "for mixed language fields")))((("multifields", "analying mixed language fields")))you could use
+If you primarily deal with a limited number of languages, you could use
 multi-fields to analyze the text once per language:
 
 [source,js]
@@ -43,22 +44,22 @@ PUT /movies
     "title": {
       "properties": {
         "title": { <1>
-          "type": "string",
+          "type": "text",
           "fields": {
             "de": { <2>
-              "type":     "string",
+              "type":     "text",
               "analyzer": "german"
             },
             "en": { <2>
-              "type":     "string",
+              "type":     "text",
               "analyzer": "english"
             },
             "fr": { <2>
-              "type":     "string",
+              "type":     "text",
               "analyzer": "french"
             },
             "es": { <2>
-              "type":     "string",
+              "type":     "text",
               "analyzer": "spanish"
             }
           }
@@ -68,15 +69,18 @@ PUT /movies
   }
 }
 --------------------------------------------------
+// CONSOLE
+
 <1> The main `title` field uses the `standard` analyzer.
 <2> Each subfield applies a different language analyzer
     to the text in the `title` field.
 
 ==== Use n-grams
 
-You could index all words as n-grams, using the ((("n-grams", "for mixed language fields")))((("languages", "mixed language fields", "n-grams, indexing words as")))same approach as
+You could index all words as n-grams, using the same approach as
 described in <<ngrams-compound-words>>.  Most inflections involve adding a
-suffix (or in some languages, a prefix) to a word, so by breaking each word into n-grams, you have a good chance of matching words that are similar
+suffix (or in some languages, a prefix) to a word, so by breaking each word into
+n-grams, you have a good chance of matching words that are similar
 but not exactly the same. This can be combined with the _analyze-multiple
 times_ approach to provide a catchall field for unsupported languages:
 
@@ -85,32 +89,50 @@ times_ approach to provide a catchall field for unsupported languages:
 PUT /movies
 {
   "settings": {
-    "analysis": {...} <1>
+    "analysis": {
+      "filter": {
+        "trigrams_filter": {
+          "type": "ngram",
+          "min_gram": 3,
+          "max_gram": 3
+        }
+      },
+      "analyzer": {
+        "trigrams": {
+          "type": "custom",
+          "tokenizer": "standard",
+          "filter": [
+            "lowercase",
+            "trigrams_filter"
+          ]
+        }
+      }
+    }
   },
   "mappings": {
     "title": {
       "properties": {
         "title": {
-          "type": "string",
+          "type": "text",
           "fields": {
             "de": {
-              "type":     "string",
+              "type": "text",
               "analyzer": "german"
             },
             "en": {
-              "type":     "string",
+              "type": "text",
               "analyzer": "english"
             },
             "fr": {
-              "type":     "string",
+              "type": "text",
               "analyzer": "french"
             },
             "es": {
-              "type":     "string",
+              "type": "text",
               "analyzer": "spanish"
             },
-            "general": { <2>
-              "type":     "string",
+            "general": { <1>
+              "type": "text",
               "analyzer": "trigrams"
             }
           }
@@ -120,9 +142,9 @@ PUT /movies
   }
 }
 --------------------------------------------------
-<1> In the `analysis` section, we define the same `trigrams`
-    analyzer as described in <<ngrams-compound-words>>.
-<2> The `title.general` field uses the `trigrams` analyzer
+// CONSOLE
+
+<1> The `title.general` field uses the `trigrams` custom analyzer
     to index any language.
 
 When querying the catchall `general` field, you can use
@@ -133,6 +155,13 @@ than those on the `general` field:
 
 [source,js]
 --------------------------------------------------
+PUT /movies/movie/1
+{ "title": "club de la lucha" }
+
+
+PUT /movies/movie/2
+{ "title": "Superhero Fight Club" }
+
 GET /movies/movie/_search
 {
     "query": {
@@ -145,8 +174,10 @@ GET /movies/movie/_search
     }
 }
 --------------------------------------------------
+// CONSOLE
+// TEST[continued]
+
 <1> All `title` or `title.*` fields are given a slight boost over the
     `title.general` field.
-<2> The `minimum_should_match` parameter reduces the number of low-quality matches returned, especially important for the `title.general` field.
-
-
+<2> The `minimum_should_match` parameter reduces the number of low-quality
+    matches returned, especially important for the `title.general` field.


### PR DESCRIPTION
This fixes up the Getting Started with Languages section:

* Remove O'Reilly index cruft
* CONSOLE-ify code snippets
* Fix deprecated Elasticsearch DSL syntax
* Where possible, add example documents so mapping changes and searches
can be properly observed
* Fix line wraps
* Remove mentions of document types