### PR TITLE
Rewrite the aggregations basic example based on taxis

### DIFF
--- a/300_Aggregations/20_basic_example.asciidoc
+++ b/300_Aggregations/20_basic_example.asciidoc
@@ -2,72 +2,139 @@
 == Aggregation Test-Drive
 
 We could spend the next few pages defining the various aggregations
-and their syntax,((("aggregations", "basic example", id="ix_basicex"))) but aggregations are truly best learned by example.
-Once you learn how to think about aggregations, and how to nest them appropriately,
-the syntax is fairly trivial.
+and their syntax, but aggregations are truly best learned by example.
+Once you learn how to think about aggregations, and how to nest them
+appropriately, the syntax is fairly trivial.
 
 [NOTE]
 =========================
-A complete list of aggregation buckets and metrics can be found at the {ref}/search-aggregations.html[Elasticsearch Reference].  We'll cover many of them in this chapter, but glance
-over it after finishing so you are familiar with the full range of capabilities.
+A complete list of aggregation buckets and metrics can be found at the
+{ref}/search-aggregations.html[Elasticsearch Reference].  We'll cover many of
+them in this chapter, but glance over it after finishing so you are familiar
+with the full range of capabilities.
 =========================
 
 So let's just dive in and start with an example.  We are going to build some
-aggregations that might be useful to a car dealer.  Our data will be about car
-transactions: the car model, manufacturer, sale price, when it sold, and more.
+aggregations that might be useful to a taxi company. Our data will be about
+taxi rides: the name of the vendor, distance, point in time at start and end, and more.
 
-First we will bulk-index some data to work with:
+To have something to play with for our aggregations, we have prepared an example
+data set instead of indexing just a handful of documents. The data set contains
+200,000 fictitious taxi rides within San Francisco that we have generated with
+a script and saved it as a snapshot in our public demo repository.  To "restore"
+this dataset into your cluster:
+
+. Add the following setting to your `elasticsearch.yml` configuration file to
+whitelist the Elastic demo repository:
++
+[source,js]
+----
+repositories.url.allowed_urls: ["http://download.elastic.co/*"]
+----
+. Restart Elasticsearch.
+
+. Run the following snapshot commands. (For more information about using
+snapshots, see <<backing-up-your-cluster, Backing Up Your Cluster>>.)
++
+[source,js]
+----
+PUT /_snapshot/taxis <1>
+{
+    "type": "url",
+    "settings": {
+        "url": "http://download.elastic.co/definitiveguide/taxis_demo/"
+    }
+}
+
+GET /_snapshot/taxis/_all <2>
+
+POST /_snapshot/taxis/snapshot/_restore <3>
+
+GET /taxis/_recovery <4>
+----
+// CONSOLE: 300_Aggregations/20_basic_example.json
+<1> Register a new read-only URL repository pointing at the demo snapshot
+<2> (Optional) Inspect the repository to learn details about available snapshots
+<3> Begin the Restore process.  This will download the `taxis` index into your cluster
+<4> (Optional) Monitor the Restore process using the Recovery API
+
+
+NOTE: The dataset is around 24 MB and may take some time to download.
+
+Let's take a look at some sample data, to get a feel for what we are working with.
+
+[source,js]
+----
+GET taxis/_search <1>
+
+{
+  "took": 13,
+  "timed_out": false,
+  "_shards": {
+    "total": 5,
+    "successful": 5,
+    "failed": 0
+  },
+  "hits": {
+    "total": 200000,
+    "max_score": 1,
+    "hits": [
+      {
+        "_index": "taxis",
+        "_type": "rides",
+        "_id": "AVwfj7ZUUUjfIbklSMXd",
+        "_score": 1,
+        "_source": {
+          "vendor": "Black",
+          "pickup_datetime": "2017-04-01 00:01:31",
+          "passenger_count": 2,
+          "dropoff_datetime": "2017-04-01 00:16:11",
+          "pickup_zone": "Haight-Ashbury",
+          "dropoff_zone": "Financial District",
+          "payment_type": "Credit card",
+          "trip_distance": 4.4,
+          "fare_amount": 22.2,
+          "tip_amount": 1.2,
+          "total_amount": 23.4
+        }
+      },
+      ...
+----
+// CONSOLE: 300_Aggregations/20_basic_example.json
+<1> Execute a search without a query, so that we can see a random sampling of documents.
+
+Each document in `taxis` represents a single taxi ride. We can see the `vendor`
+as well as how many passengers were on the ride and other details.
+
+Now that we have some data, let's construct our first aggregation.  A taxi
+company may want to know the number of rides per vendor to better understand
+the local taxi market. This is easily accomplished using a simple aggregation.
+We will do this using a `terms` bucket:
 
 [source,js]
 --------------------------------------------------
-POST /cars/transactions/_bulk
-{ "index": {}}
-{ "price" : 10000, "color" : "red", "make" : "honda", "sold" : "2014-10-28" }
-{ "index": {}}
-{ "price" : 20000, "color" : "red", "make" : "honda", "sold" : "2014-11-05" }
-{ "index": {}}
-{ "price" : 30000, "color" : "green", "make" : "ford", "sold" : "2014-05-18" }
-{ "index": {}}
-{ "price" : 15000, "color" : "blue", "make" : "toyota", "sold" : "2014-07-02" }
-{ "index": {}}
-{ "price" : 12000, "color" : "green", "make" : "toyota", "sold" : "2014-08-19" }
-{ "index": {}}
-{ "price" : 20000, "color" : "red", "make" : "honda", "sold" : "2014-11-05" }
-{ "index": {}}
-{ "price" : 80000, "color" : "red", "make" : "bmw", "sold" : "2014-01-01" }
-{ "index": {}}
-{ "price" : 25000, "color" : "blue", "make" : "ford", "sold" : "2014-02-12" }
---------------------------------------------------
-// SENSE: 300_Aggregations/20_basic_example.json
-
-Now that we have some data, let's construct our first aggregation.  A car dealer
-may want to know which color car sells the best.  This is easily accomplished
-using a simple aggregation.  We will do this using a `terms` bucket:
-
-[source,js]
---------------------------------------------------
-GET /cars/transactions/_search
+GET /taxis/_search
 {
     "size" : 0,
     "aggs" : { <1>
-        "popular_colors" : { <2>
+        "rides_per_vendor" : { <2>
             "terms" : { <3>
-              "field" : "color.keyword"
+              "field" : "vendor"
             }
         }
     }
 }
 --------------------------------------------------
-// SENSE: 300_Aggregations/20_basic_example.json
+// CONSOLE: 300_Aggregations/20_basic_example.json
 
-<1> Aggregations are placed under the ((("aggregations", "aggs parameter")))top-level `aggs` parameter (the longer `aggregations`
-will also work if you prefer that).
-<2> We then name the aggregation whatever we want: `popular_colors`, in this example
+<1> Aggregations are placed under the top-level `aggs` parameter (the longer
+`aggregations` will also work if you prefer that).
+<2> We then name the aggregation whatever we want: `rides_per_vendor`, in this example
 <3> Finally, we define a single bucket of type `terms`.
 
-Aggregations are executed in the context of search results,((("searching", "aggregations executed in context of search results"))) which means it is
+Aggregations are executed in the context of search results, which means it is
 just another top-level parameter in a search request (for example, using the `/_search`
-endpoint).  Aggregations can be paired with queries, but we'll tackle that later
+endpoint). Aggregations can be paired with queries, but we'll tackle that later
 in <<_scoping_aggregations>>.
 
 [NOTE]
@@ -77,14 +144,14 @@ don't care about the search results themselves and
 returning zero hits speeds up the query.
 =========================
 
-Next we define a name for our aggregation.  Naming is up to you;
-the response will be labeled with the name you provide so that your application
-can parse the results later.
+Next we define a name for our aggregation. Naming is up to you; the response
+will be labeled with the name you provide so that your application can parse
+the results later.
 
-Next we define the aggregation itself.  For this example, we are defining
-a single `terms` bucket.((("buckets", "terms bucket (example)")))((("terms bucket", "defining in example aggregation")))  The `terms` bucket will dynamically create a new
-bucket for every unique term it encounters.  Since we are telling it to use the
-`color` field, the `terms` bucket will dynamically create a new bucket for each color.
+Next we define the aggregation itself. For this example, we are defining a
+single `terms` bucket. The `terms` bucket will dynamically create a new
+bucket for every unique term it encounters. Since we are telling it to use the
+`vendor` field, the `terms` bucket will dynamically create a new bucket for each vendor.
 
 
 Let's execute that aggregation and take a look at the results:
@@ -93,49 +160,56 @@ Let's execute that aggregation and take a look at the results:
 --------------------------------------------------
 {
 ...
-   "hits": {
+  "hits": {
       ...
       "hits": [] <1>
-   },
-   "aggregations": {
-      "popular_colors": { <2>
-         ...
-         "buckets": [
-            {
-               "key": "red", <3>
-               "doc_count": 4 <4>
-            },
-            {
-               "key": "blue",
-               "doc_count": 2
-            },
-            {
-               "key": "green",
-               "doc_count": 2
-            }
-         ]
-      }
-   }
+  },
+  "aggregations": {
+    "rides_per_vendor": { <2>
+      ...
+      "buckets": [
+        {
+          "key": "Green", <3>
+          "doc_count": 40125 <4>
+        },
+        {
+          "key": "Black",
+          "doc_count": 40078
+        },
+        {
+          "key": "Blue",
+          "doc_count": 39997
+        },
+        {
+          "key": "Red",
+          "doc_count": 39929
+        },
+        {
+          "key": "Yellow",
+          "doc_count": 39871
+        }
+      ]
+    }
+  }
 }
 --------------------------------------------------
 <1> No search hits are returned because we set the `size` parameter to zero.
-<2> Our `popular_colors` aggregation is returned as part of the `aggregations` field.
-<3> The `key` to each bucket corresponds to a unique term found in the `color` field.
-It also always includes `doc_count`, which tells us the number of docs containing the term.
+<2> Our `rides_per_vendor` aggregation is returned as part of the `aggregations` field.
+<3> The `key` to each bucket corresponds to a unique term found in the `vendor` field.
+It also always includes `doc_count`, which tells us the number of documents containing the term.
 <4> The count of each bucket represents the number of documents with this color.
 
-The ((("doc_count")))response contains a list of buckets, each corresponding to a unique color
-(for example, red or green). Each bucket also includes a count of the number of documents
-that "fell into" that particular bucket.  For example, there are four red cars.
+The response contains a list of buckets, each corresponding to a vendor (for example, "Red" or "Green").
+Each bucket also includes a count of the number of documents that "fell into" that particular bucket.
+For example, we can see that the "Black" vendor has conducted 40,078 rides in total.
 
 The preceding example is operating entirely in real time: if the documents are searchable,
 they can be aggregated.  This means you can take the aggregation results and
 pipe them straight into a graphing library to generate real-time dashboards.
-As soon as you sell a silver car, your graphs would dynamically update to include
-statistics about silver cars.
+As soon as you drop-off a customer, your graphs would dynamically update to include
+statistics about the number of rides.
 
 Voila!  Your first aggregation!
-((("aggregations", "basic example", startref ="ix_basicex")))
 
 
 

--- a/300_Aggregations/20_basic_example.asciidoc
+++ b/300_Aggregations/20_basic_example.asciidoc
@@ -59,7 +59,7 @@ GET /taxis/_recovery <4>
 <4> (Optional) Monitor the Restore process using the Recovery API
 
 
-NOTE: The dataset is around 24 MB and may take some time to download.
+NOTE: The dataset is around 25 MB and may take some time to download.
 
 Let's take a look at some sample data, to get a feel for what we are working with.
 
@@ -80,22 +80,22 @@ GET taxis/_search <1>
     "max_score": 1,
     "hits": [
       {
-        "_index": "taxis",
-        "_type": "rides",
-        "_id": "AVwfj7ZUUUjfIbklSMXd",
-        "_score": 1,
-        "_source": {
-          "vendor": "Black",
-          "pickup_datetime": "2017-04-01 00:01:31",
-          "passenger_count": 2,
-          "dropoff_datetime": "2017-04-01 00:16:11",
-          "pickup_zone": "Haight-Ashbury",
-          "dropoff_zone": "Financial District",
-          "payment_type": "Credit card",
-          "trip_distance": 4.4,
-          "fare_amount": 22.2,
-          "tip_amount": 1.2,
-          "total_amount": 23.4
+        "_index" : "taxis",
+        "_type" : "rides",
+        "_id" : "5HFoQV0BWEIjXA7uwI57",
+        "_score" : 1.0,
+        "_source" : {
+          "vendor" : "Blue",
+          "pickup_datetime" : "2017-06-01 00:01:16",
+          "passenger_count" : 1,
+          "dropoff_datetime" : "2017-06-01 00:30:25",
+          "pickup_zone" : "Sunset",
+          "dropoff_zone" : "Chinatown",
+          "payment_type" : "Credit card",
+          "trip_distance" : 10.2,
+          "fare_amount" : 48.38,
+          "tip_amount" : 4.03,
+          "total_amount" : 52.41
         }
       },
       ...
@@ -169,24 +169,24 @@ Let's execute that aggregation and take a look at the results:
       ...
       "buckets": [
         {
-          "key": "Green", <3>
-          "doc_count": 40125 <4>
+          "key" : "Green", <3>
+          "doc_count" : 50253 <4>
         },
         {
-          "key": "Black",
-          "doc_count": 40078
+          "key" : "Black",
+          "doc_count" : 49862
         },
         {
-          "key": "Blue",
-          "doc_count": 39997
+          "key" : "Red",
+          "doc_count" : 39800
         },
         {
-          "key": "Red",
-          "doc_count": 39929
+          "key" : "Yellow",
+          "doc_count" : 34062
         },
         {
-          "key": "Yellow",
-          "doc_count": 39871
+          "key" : "Blue",
+          "doc_count" : 26023
         }
       ]
     }
@@ -201,7 +201,7 @@ It also always includes `doc_count`, which tells us the number of documents cont
 
 The response contains a list of buckets, each corresponding to a vendor (for example, "Red" or "Green").
 Each bucket also includes a count of the number of documents that "fell into" that particular bucket.
-For example, we can see that the "Black" vendor has conducted 40,078 rides in total.
+For example, we can see that the "Black" vendor has conducted 49,862 rides in total.
 
 The preceding example is operating entirely in real time: if the documents are searchable,
 they can be aggregated.  This means you can take the aggregation results and

--- a/300_Aggregations/21_add_metric.asciidoc
+++ b/300_Aggregations/21_add_metric.asciidoc
@@ -2,30 +2,30 @@
 === Adding a Metric to the Mix
 
 The previous example told us the number of documents in each bucket, which is
-useful.  ((("aggregations", "basic example", "adding a metric")))But often, our applications require more-sophisticated metrics about
-the documents.((("metrics", "adding to basic aggregation (example)"))) For example, what is the average price of cars in each bucket?
+useful. But often, our applications require more-sophisticated metrics about
+the documents. For example, what is the average revenue of each vendor?
 
-To get this information, we need to tell Elasticsearch which metrics to calculate,
-and on which fields. ((("buckets", "nesting metrics in"))) This requires _nesting_ metrics inside the buckets.
-Metrics will calculate mathematical statistics based on the values of documents
-within a bucket.
+To get this information, we need to tell Elasticsearch which metrics to
+calculate, and on which fields. This requires _nesting_ metrics inside the
+buckets. Metrics will calculate mathematical statistics based on the values of
+documents within a bucket.
 
-Let's go ahead and add ((("average metric")))an `average` metric to our car example:
+Let's go ahead and add an `average` metric to our taxis example:
 
 [source,js]
 --------------------------------------------------
-GET /cars/transactions/_search
+GET /taxis/_search
 {
    "size" : 0,
    "aggs": {
-      "colors": {
+      "vendors": {
          "terms": {
-            "field": "color.keyword"
+            "field": "vendor"
          },
          "aggs": { <1>
-            "avg_price": { <2>
+            "avg_revenue": { <2>
                "avg": {
-                  "field": "price" <3>
+                  "field": "total_amount" <3>
                }
             }
          }
@@ -33,58 +33,72 @@ GET /cars/transactions/_search
    }
 }
 --------------------------------------------------
-// SENSE: 300_Aggregations/20_basic_example.json
+// CONSOLE: 300_Aggregations/20_basic_example.json
 <1> We add a new `aggs` level to hold the metric.
-<2> We then give the metric a name: `avg_price`.
-<3> And finally, we define it as an `avg` metric over the `price` field.
+<2> We then give the metric a name: `avg_revenue`.
+<3> And finally, we define it as an `avg` metric over the `total_amount` field.
 
 As you can see, we took the previous example and tacked on a new `aggs` level.
 This new aggregation level allows us to nest the `avg` metric inside the
 `terms` bucket.  Effectively, this means we will generate an average for each
-color.
+vendor.
 
-Just like the `colors` example, we need to name our metric (`avg_price`) so we
-can retrieve the values later.  Finally, we specify the metric itself (`avg`)
-and what field we want the average to be calculated on (`price`):
+Just like the `rides_per_vendor` example, we need to name our metric (`avg_revenue`)
+so we can retrieve the values later.  Finally, we specify the metric itself (`avg`)
+and what field we want the average to be calculated on (`total_amount`):
 
 [source,js]
 --------------------------------------------------
 {
-...
-   "aggregations": {
-      "colors": {
-         ...
-         "buckets": [
-            {
-               "key": "red",
-               "doc_count": 4,
-               "avg_price": { <1>
-                  "value": 32500
-               }
-            },
-            {
-               "key": "blue",
-               "doc_count": 2,
-               "avg_price": {
-                  "value": 20000
-               }
-            },
-            {
-               "key": "green",
-               "doc_count": 2,
-               "avg_price": {
-                  "value": 21000
-               }
-            }
-         ]
-      }
-   }
-...
+  ...
+  "aggregations": {
+    "vendors": {
+      ...
+      "buckets": [
+        {
+          "key": "Green",
+          "doc_count": 40125,
+          "avg_revenue": { <1>
+            "value": 22.570584423675992
+          }
+        },
+        {
+          "key": "Black",
+          "doc_count": 40078,
+          "avg_revenue": {
+            "value": 22.614081291481632
+          }
+        },
+        {
+          "key": "Blue",
+          "doc_count": 39997,
+          "avg_revenue": {
+            "value": 22.59631597369808
+          }
+        },
+        {
+          "key": "Red",
+          "doc_count": 39929,
+          "avg_revenue": {
+            "value": 22.73482431315584
+          }
+        },
+        {
+          "key": "Yellow",
+          "doc_count": 39871,
+          "avg_revenue": {
+            "value": 22.601132401996455
+          }
+        }
+      ]
+    }
+  }
 }
 --------------------------------------------------
-<1> New `avg_price` element in response
+<1> New `avg_revenue` element in response
 
 Although the response has changed minimally, the data we get out of it has grown
-substantially.  Before, we knew there were four red cars.  Now we know that the
-average price of red cars is $32,500.  This is something that you can plug directly
+substantially.  Before, we knew that we have five different taxi vendors and how
+many rides each of them handles.  Now we know that the average revenue of the
+"Black" vendor is is $22.61. This is something that you can plug directly
 into reports or graphs.

--- a/300_Aggregations/21_add_metric.asciidoc
+++ b/300_Aggregations/21_add_metric.asciidoc
@@ -55,39 +55,39 @@ and what field we want the average to be calculated on (`total_amount`):
     "vendors": {
       ...
       "buckets": [
-        {
-          "key": "Green",
-          "doc_count": 40125,
-          "avg_revenue": { <1>
-            "value": 22.570584423675992
+{
+          "key" : "Green",
+          "doc_count" : 50253,
+          "avg_revenue" : { <1>
+            "value" : 22.447771675322958
           }
         },
         {
-          "key": "Black",
-          "doc_count": 40078,
-          "avg_revenue": {
-            "value": 22.614081291481632
+          "key" : "Black",
+          "doc_count" : 49862,
+          "avg_revenue" : {
+            "value" : 22.613874092495085
           }
         },
         {
-          "key": "Blue",
-          "doc_count": 39997,
-          "avg_revenue": {
-            "value": 22.59631597369808
+          "key" : "Red",
+          "doc_count" : 39800,
+          "avg_revenue" : {
+            "value" : 22.31519195979896
           }
         },
         {
-          "key": "Red",
-          "doc_count": 39929,
-          "avg_revenue": {
-            "value": 22.73482431315584
+          "key" : "Yellow",
+          "doc_count" : 34062,
+          "avg_revenue" : {
+            "value" : 22.063510950619435
           }
         },
         {
-          "key": "Yellow",
-          "doc_count": 39871,
-          "avg_revenue": {
-            "value": 22.601132401996455
+          "key" : "Blue",
+          "doc_count" : 26023,
+          "avg_revenue" : {
+            "value" : 22.01809399377478
           }
         }
       ]

--- a/300_Aggregations/22_nested_bucket.asciidoc
+++ b/300_Aggregations/22_nested_bucket.asciidoc
@@ -2,59 +2,59 @@
 === Buckets Inside Buckets
 
 The true power of aggregations becomes apparent once you start playing with
-different nesting schemes.((("aggregations", "basic example", "buckets nested in other buckets")))((("buckets", "nested in other buckets")))  In the previous examples, we saw how you could nest
+different nesting schemes. In the previous examples, we saw how you could nest
 a metric inside a bucket, which is already quite powerful.
 
 But the real exciting analytics come from nesting buckets inside _other buckets_.
-This time, we want to find out the distribution of car manufacturers for each
-color:
+This time, we want to find out the distribution of passengers for each vendor:
 
 
 [source,js]
 --------------------------------------------------
-GET /cars/transactions/_search
+GET /taxis/_search
 {
    "size" : 0,
    "aggs": {
-      "colors": {
+      "vendors": {
          "terms": {
-            "field": "color"
+            "field": "vendor"
          },
          "aggs": {
-            "avg_price": { <1>
+            "avg_revenue": { <1>
                "avg": {
-                  "field": "price"
+                  "field": "total_amount"
                }
             },
-            "make": { <2>
-                "terms": {
-                    "field": "make" <3>
-                }
+            "passengers": { <2>
+              "terms": {
+                "field": "passenger_count" <3>
+              }
             }
          }
       }
    }
 }
 --------------------------------------------------
-// SENSE: 300_Aggregations/20_basic_example.json
-<1> Notice that we can leave the previous `avg_price` metric in place.
-<2> Another aggregation named `make` is added to the `color` bucket.
+// CONSOLE: 300_Aggregations/20_basic_example.json
+<1> Notice that we can leave the previous `avg_revenue` metric in place.
+<2> Another aggregation named `passengers` is added to the `vendors` bucket.
 <3> This aggregation is a `terms` bucket and will generate unique buckets for
-each car make.
+each passenger count.
 
-A few interesting things happened here.((("metrics", "independent, on levels of an aggregation")))  First, you'll notice that the previous
-`avg_price` metric is left entirely intact.  Each _level_ of an aggregation can
-have many metrics or buckets.  The `avg_price` metric tells us the average price
-for each car color.  This is independent of other buckets and metrics that
+A few interesting things happened here. First, you'll notice that the previous
+`avg_revenue` metric is left entirely intact. Each _level_ of an aggregation can
+have many metrics or buckets. The `avg_revenue` metric tells us the average revenue
+for each taxi vendor. This is independent of other buckets and metrics that
 are also being built.
 
 This is important for your application, since there are often many related,
 but entirely distinct, metrics that you need to collect.  Aggregations allow
 you to collect all of them in a single pass over the data.
 
-The other important thing to note is that the aggregation we added, `make`, is
-a `terms` bucket (nested inside the `colors` `terms` bucket).  This means we will((("terms bucket", "nested in another terms bucket")))
-generate a (`color`, `make`) tuple for every unique combination in your dataset.
+The other important thing to note is that the aggregation we added, `passengers`,
+is a `terms` bucket (nested inside the `vendors` `terms` bucket).  This means
+we will generate a (`vendors`, `passengers`) tuple for every unique combination
+in your dataset.
 
 Let's take a look at the response (truncated for brevity, since it is now
 growing quite long):
@@ -62,6 +62,54 @@ growing quite long):
 
 [source,js]
 --------------------------------------------------
+{
+  ...
+  "aggregations": {
+    "vendors": {
+      ...
+      "buckets": [
+        {
+          "key": "Black",
+          "doc_count": 40078,
+          "passengers": { <1>
+            ...
+            "buckets": [
+              {
+                "key": 1, <2>
+                "doc_count": 26299
+              },
+              {
+                "key": 2,
+                "doc_count": 6500
+              },
+              {
+                "key": 3,
+                "doc_count": 3045
+              },
+              {
+                "key": 6,
+                "doc_count": 1751
+              },
+              {
+                "key": 4,
+                "doc_count": 1574
+              },
+              {
+                "key": 5,
+                "doc_count": 909
+              }
+            ]
+          },
+          "avg_revenue": {
+            "value": 22.614081291481632 <3>
+          }
+        },
+        ...
+      ]
+    }
+  }
+}
+
 {
 ...
    "aggregations": {
@@ -90,12 +138,12 @@ growing quite long):
 ...
 }
 --------------------------------------------------
-<1> Our new aggregation is nested under each color bucket, as expected.
-<2> We now see a breakdown of car makes for each color.
-<3> Finally, you can see that our previous `avg_price` metric is still intact.
+<1> Our new aggregation is nested under each vendor bucket, as expected.
+<2> We now see a breakdown of passenger counts for each vendor.
+<3> Finally, you can see that our previous `avg_revenue` metric is still intact.
 
 The response tells us the following:
 
-- There are four red cars.
-- The average price of a red car is $32,500.
-- Three of the red cars are made by Honda, and one is a BMW.
+- There are five different taxi vendors.
+- The average revenue per ride of the "Black" vendor is $22.61.
+- Most of the time (26,299 out of a total 40,078) they have only one passenger.

--- a/300_Aggregations/22_nested_bucket.asciidoc
+++ b/300_Aggregations/22_nested_bucket.asciidoc
@@ -69,73 +69,41 @@ growing quite long):
       ...
       "buckets": [
         {
-          "key": "Black",
-          "doc_count": 40078,
-          "passengers": { <1>
+          "key" : "Black",
+          "doc_count" : 49862,
+          "passengers" : { <1>
             ...
-            "buckets": [
+            "buckets" : [
               {
-                "key": 1, <2>
-                "doc_count": 26299
+                "key" : 1, <2>
+                "doc_count" : 32819
               },
               {
-                "key": 2,
-                "doc_count": 6500
+                "key" : 2,
+                "doc_count" : 8128
               },
               {
-                "key": 3,
-                "doc_count": 3045
+                "key" : 3,
+                "doc_count" : 3728
               },
               {
-                "key": 6,
-                "doc_count": 1751
+                "key" : 5,
+                "doc_count" : 3278
               },
               {
-                "key": 4,
-                "doc_count": 1574
-              },
-              {
-                "key": 5,
-                "doc_count": 909
+                "key" : 4,
+                "doc_count" : 1909
               }
             ]
           },
-          "avg_revenue": {
-            "value": 22.614081291481632 <3>
+          "avg_revenue" : {
+            "value" : 22.613874092495085 <3>
           }
         },
         ...
       ]
     }
   }
-}
-
-{
-...
-   "aggregations": {
-      "colors": {
-         "buckets": [
-            {
-               "key": "red",
-               "doc_count": 4,
-               "make": { <1>
-                  "buckets": [
-                     {
-                        "key": "honda", <2>
-                        "doc_count": 3
-                     },
-                     {
-                        "key": "bmw",
-                        "doc_count": 1
-                     }
-                  ]
-               },
-               "avg_price": {
-                  "value": 32500 <3>
-               }
-            },
-
-...
 }
 --------------------------------------------------
 <1> Our new aggregation is nested under each vendor bucket, as expected.
@@ -146,4 +114,4 @@ The response tells us the following:
 
 - There are five different taxi vendors.
 - The average revenue per ride of the "Black" vendor is $22.61.
-- Most of the time (26,299 out of a total 40,078) they have only one passenger.
+- Most of the time (32,819 out of a total 49,862) they have only one passenger.

--- a/300_Aggregations/23_extra_metrics.asciidoc
+++ b/300_Aggregations/23_extra_metrics.asciidoc
@@ -3,92 +3,140 @@
 === One Final Modification
 
 Just to drive the point home, let's make one final modification to our example
-before moving on to new topics.((("aggregations", "basic example", "adding extra metrics")))((("metrics", "adding more to aggregation (example)")))  Let's add two metrics to calculate the min and
-max price for each make:
+before moving on to new topics. Let's add two metrics to calculate the min and
+max tip per ride for each passenger count:
 
 
 [source,js]
 --------------------------------------------------
-GET /cars/transactions/_search
+GET /taxis/_search
 {
-   "size" : 0,
-   "aggs": {
-      "colors": {
-         "terms": {
-            "field": "color"
-         },
-         "aggs": {
-            "avg_price": { "avg": { "field": "price" }
-            },
-            "make" : {
-                "terms" : {
-                    "field" : "make"
-                },
-                "aggs" : { <1>
-                    "min_price" : { "min": { "field": "price"} }, <2>
-                    "max_price" : { "max": { "field": "price"} } <3>
-                }
-            }
-         }
+  "size": 0,
+  "aggs": {
+    "vendors": {
+      "terms": {
+        "field": "vendor"
+      },
+      "aggs": {
+        "avg_revenue": {
+          "avg": {
+            "field": "total_amount"
+          }
+        },
+        "passengers": {
+          "terms": {
+            "field": "passenger_count"
+          },
+          "aggs": { <1>
+            "min_tip": { "min": { "field": "tip_amount" } }, <2>
+            "max_tip": { "max": { "field": "tip_amount" } }  <3>
+          }
+        }
       }
-   }
+    }
+  }
 }
 --------------------------------------------------
-// SENSE: 300_Aggregations/20_basic_example.json
+// CONSOLE: 300_Aggregations/20_basic_example.json
 
 <1> We need to add another `aggs` level for nesting.
 <2> Then we include a `min` metric.
 <3> And a `max` metric.
 
-Which gives ((("min and max metrics (aggregation example)")))us the following output (again, truncated):
+Which gives us the following output (again, truncated):
 
 [source,js]
 --------------------------------------------------
 {
-...
-   "aggregations": {
-      "colors": {
-         "buckets": [
-            {
-               "key": "red",
-               "doc_count": 4,
-               "make": {
-                  "buckets": [
-                     {
-                        "key": "honda",
-                        "doc_count": 3,
-                        "min_price": {
-                           "value": 10000 <1>
-                        },
-                        "max_price": {
-                           "value": 20000 <1>
-                        }
-                     },
-                     {
-                        "key": "bmw",
-                        "doc_count": 1,
-                        "min_price": {
-                           "value": 80000
-                        },
-                        "max_price": {
-                           "value": 80000
-                        }
-                     }
-                  ]
-               },
-               "avg_price": {
-                  "value": 32500
-               }
-            },
-...
+  ...
+  "aggregations": {
+    "vendors": {
+      ...
+      "buckets": [
+        {
+          "key": "Black",
+          "doc_count": 40078,
+          "passengers": {
+            ...
+            "buckets": [
+              {
+                "key": 1,
+                "doc_count": 26299,
+                "min_tip": {
+                  "value": 0 <1>
+                },
+                "max_tip": {
+                  "value": 10 <1>
+                }
+              },
+              {
+                "key": 2,
+                "doc_count": 6500,
+                "min_tip": {
+                  "value": 0
+                },
+                "max_tip": {
+                  "value": 10
+                }
+              },
+              {
+                "key": 3,
+                "doc_count": 3045,
+                "min_tip": {
+                  "value": 0
+                },
+                "max_tip": {
+                  "value": 10
+                }
+              },
+              {
+                "key": 6,
+                "doc_count": 1751,
+                "min_tip": {
+                  "value": 0
+                },
+                "max_tip": {
+                  "value": 10
+                }
+              },
+              {
+                "key": 4,
+                "doc_count": 1574,
+                "min_tip": {
+                  "value": 0
+                },
+                "max_tip": {
+                  "value": 9.6
+                }
+              },
+              {
+                "key": 5,
+                "doc_count": 909,
+                "min_tip": {
+                  "value": 0
+                },
+                "max_tip": {
+                  "value": 9.8
+                }
+              }
+            ]
+          },
+          "avg_revenue": {
+            "value": 22.614081291481632
+          }
+        },
+        ...
+      ]
+    }
+  }
+}
 --------------------------------------------------
 <1> The `min` and `max` metrics that we added now appear under each `make`
 
 With those two buckets, we've expanded the information derived from this query
 to include the following:
 
-- There are four red cars.
-- The average price of a red car is $32,500.
-- Three of the red cars are made by Honda, and one is a BMW.
-- The cheapest red Honda is $10,000.
-- The most expensive red Honda is $20,000.
+- There are five different taxi vendors.
+- The average revenue per ride of the "Black" vendor is $22.61.
+- Most of the time (26,299 out of a total 40,078) they have only one passenger.
+- Single passengers give no tip or tip up to $10.

--- a/300_Aggregations/23_extra_metrics.asciidoc
+++ b/300_Aggregations/23_extra_metrics.asciidoc
@@ -54,75 +54,65 @@ Which gives us the following output (again, truncated):
       ...
       "buckets": [
         {
-          "key": "Black",
-          "doc_count": 40078,
-          "passengers": {
+          "key" : "Black",
+          "doc_count" : 49862,
+          "passengers" : {
             ...
-            "buckets": [
+            "buckets" : [
               {
-                "key": 1,
-                "doc_count": 26299,
-                "min_tip": {
-                  "value": 0 <1>
+                "key" : 1,
+                "doc_count" : 32819,
+                "min_tip" : {
+                  "value" : 0.0 <1>
                 },
-                "max_tip": {
-                  "value": 10 <1>
+                "max_tip" : {
+                  "value" : 9.18 <1>
                 }
               },
               {
-                "key": 2,
-                "doc_count": 6500,
-                "min_tip": {
-                  "value": 0
+                "key" : 2,
+                "doc_count" : 8128,
+                "min_tip" : {
+                  "value" : 0.0
                 },
-                "max_tip": {
-                  "value": 10
+                "max_tip" : {
+                  "value" : 9.18
                 }
               },
               {
-                "key": 3,
-                "doc_count": 3045,
-                "min_tip": {
-                  "value": 0
+                "key" : 3,
+                "doc_count" : 3728,
+                "min_tip" : {
+                  "value" : 0.0
                 },
-                "max_tip": {
-                  "value": 10
+                "max_tip" : {
+                  "value" : 9.0
                 }
               },
               {
-                "key": 6,
-                "doc_count": 1751,
-                "min_tip": {
-                  "value": 0
+                "key" : 5,
+                "doc_count" : 3278,
+                "min_tip" : {
+                  "value" : 0.0
                 },
-                "max_tip": {
-                  "value": 10
+                "max_tip" : {
+                  "value" : 8.82
                 }
               },
               {
-                "key": 4,
-                "doc_count": 1574,
-                "min_tip": {
-                  "value": 0
+                "key" : 4,
+                "doc_count" : 1909,
+                "min_tip" : {
+                  "value" : 0.0
                 },
-                "max_tip": {
-                  "value": 9.6
-                }
-              },
-              {
-                "key": 5,
-                "doc_count": 909,
-                "min_tip": {
-                  "value": 0
-                },
-                "max_tip": {
-                  "value": 9.8
+                "max_tip" : {
+                  "value" : 9.0
                 }
               }
             ]
           },
-          "avg_revenue": {
-            "value": 22.614081291481632
+          "avg_revenue" : {
+            "value" : 22.613874092495085
           }
         },
         ...
@@ -131,12 +121,12 @@ Which gives us the following output (again, truncated):
   }
 }
 --------------------------------------------------
-<1> The `min` and `max` metrics that we added now appear under each `make`
+<1> The `min` and `max` metrics that we added now appear under each `passengers` count.
 
 With those two buckets, we've expanded the information derived from this query
 to include the following:
 
 - There are five different taxi vendors.
 - The average revenue per ride of the "Black" vendor is $22.61.
-- Most of the time (26,299 out of a total 40,078) they have only one passenger.
-- Single passengers give no tip or tip up to $10.
+- Most of the time (32,819 out of a total 49,862) they have only one passenger.
+- Single passengers give no tip or tip up to $9.18.

--- a/scripts/300_Aggregations/generate.py
+++ b/scripts/300_Aggregations/generate.py
@@ -6,12 +6,57 @@ import random
 import datetime
 import math
 
+
+class Vendor:
+    def __init__(self, name, market_share, max_tip, p_credit_card, p_cash, min_passengers, max_passengers):
+        self.name = name
+        self.market_share = market_share
+        self.p_credit_card = 100 * p_credit_card
+        self.p_cash = 100 * p_cash
+        self.min_passengers = min_passengers
+        self.max_passengers = max_passengers
+        self.max_tip = max_tip
+        # on average 15
+        self.min_miles_per_hour = random.randint(13, 17)
+        # on average 25
+        self.max_miles_per_hour = random.randint(21, 29)
+
+    def payment_type(self):
+        v = random.uniform(0, 100)
+        if v < self.p_credit_card:
+            return "Credit card"
+        elif v < self.p_credit_card + self.p_cash:
+            return "Cash"
+        else:
+            return "No charge"
+
+    def passengers(self):
+        return min(self.max_passengers, max(self.min_passengers, round(random.lognormvariate(mu=0, sigma=1))))
+
+    def distance(self, start, end):
+        base = distances_in_miles[start][end]
+        return base + 0.2 * random.randint(0, max(base, 1))
+
+    def duration(self, dist_miles):
+        return datetime.timedelta(hours=dist_miles / random.randint(self.min_miles_per_hour, self.max_miles_per_hour))
+
+    def fare(self, trip_distance):
+        # loosely based on https://www.sfmta.com/getting-around/taxi/taxi-rates
+        # assume a random waiting time up to 10% of the distance
+        waiting_time_units = 0.1 * random.randint(0, round(trip_distance))
+        trip_units = max(0, round(trip_distance / 0.125) - 1)
+        return 3.5 + 0.55 * (trip_units + waiting_time_units)
+
+    def tip(self, fare_amount):
+        return self.max_tip * random.randint(0, round(fare_amount))
+
+
 vendors = [
-    "Yellow",
-    "Green",
-    "Blue",
-    "Red",
-    "Black"
+    Vendor(name="Yellow", market_share=0.17, max_tip=0.14, p_credit_card=0.7, p_cash=0.25, min_passengers=1, max_passengers=8),
+    Vendor(name="Green", market_share=0.25, max_tip=0.17, p_credit_card=0.79, p_cash=0.2, min_passengers=1, max_passengers=4),
+    Vendor(name="Blue", market_share=0.13, max_tip=0.13, p_credit_card=0.8, p_cash=0.15, min_passengers=1, max_passengers=6),
+    Vendor(name="Red", market_share=0.2, max_tip=0.15, p_credit_card=0.7, p_cash=0.3, min_passengers=1, max_passengers=10),
+    Vendor(name="Black", market_share=0.25, max_tip=0.18, p_credit_card=0.6, p_cash=0.35, min_passengers=1, max_passengers=5),
 ]
 
 all_zones = [
@@ -93,45 +138,22 @@ distances_in_miles = {
 }
 
 
-def payment_type():
-    v = random.uniform(0, 10)
-    if v < 7:
-        return "Credit card"
-    elif v < 9.5:
-        return "Cash"
-    else:
-        return "No charge"
+def choose_vendor():
+    # see https://docs.python.org/3.6/library/random.html#random.choices
+    # return random.choices(vendors, cum_weights=[v.market_share for v in vendors])[0]
+    return weighted_choice(vendors)
 
 
-def vendor():
-    return random.choice(vendors)
-
-
-def passengers():
-    return min(6, max(1, round(random.lognormvariate(mu=0, sigma=1))))
-
-
-def distance(start, end):
-    base = distances_in_miles[start][end]
-    return base + 0.2 * random.randint(0, max(base, 1))
-
-
-def duration(dist_miles):
-    # 15 - 25 miles per hour on average
-    return datetime.timedelta(hours=dist_miles / random.randint(15, 25))
-
-
-def fare(trip_distance):
-    # loosely based on https://www.sfmta.com/getting-around/taxi/taxi-rates
-    # assume a random waiting time up to 10% of the distance
-    waiting_time_factor = 0.55 * 0.1 * random.randint(0, round(trip_distance))
-    units = max(0, round(trip_distance / 0.125) - 1)
-    return 3.5 + units * 0.55
-
-
-def tip(fare_amount):
-    # up to 20% tip
-    return 0.2 * random.randint(0, round(fare_amount))
+def weighted_choice(choices):
+    # based on https://stackoverflow.com/a/26196078/6429186
+    r = random.uniform(0.0, 1.0)
+    upto = 0
+    for c in choices:
+        w = c.market_share
+        if upto + w >= r:
+            return c
+        upto += w
+    assert False, "Shouldn't get here"
 
 
 def round_f(v):
@@ -176,26 +198,27 @@ def main():
         print("usage: %s number_of_records_to_generate" % sys.argv[0])
         exit(1)
 
-    current = datetime.datetime(year=2017, month=4, day=1)
+    current = datetime.datetime(year=2017, month=6, day=1)
     num_records = int(sys.argv[1])
     for i in range(num_records):
         record = {}
         current = generate_timestamp(current)
-        record["vendor"] = vendor()
+        vendor = choose_vendor()
+        record["vendor"] = vendor.name
         record["pickup_datetime"] = format_ts(current)
-        record["passenger_count"] = passengers()
+        record["passenger_count"] = vendor.passengers()
 
         start = random.choice(zones)
         end = random.choice(zones)
-        trip_distance = distance(start, end)
-        record["dropoff_datetime"] = format_ts(current + duration(trip_distance))
+        trip_distance = vendor.distance(start, end)
+        record["dropoff_datetime"] = format_ts(current + vendor.duration(trip_distance))
 
         record["pickup_zone"] = start
         record["dropoff_zone"] = end
-        record["payment_type"] = payment_type()
+        record["payment_type"] = vendor.payment_type()
         record["trip_distance"] = round_f(trip_distance)
-        fare_amount = round_f(fare(trip_distance))
-        tip_amount = round_f(tip(fare_amount))
+        fare_amount = round_f(vendor.fare(trip_distance))
+        tip_amount = round_f(vendor.tip(fare_amount))
         record["fare_amount"] = fare_amount
         record["tip_amount"] = tip_amount
         record["total_amount"] = round_f(fare_amount + tip_amount)

--- a/snippets/300_Aggregations/20_basic_example.json
+++ b/snippets/300_Aggregations/20_basic_example.json
@@ -1,52 +1,51 @@
-# Delete the `cars` index
-DELETE /cars
+# Register the taxis demo repository
+PUT /_snapshot/taxis
+{
+  "type": "url",
+  "settings": {
+    "url": "http://download.elastic.co/definitiveguide/taxis_demo/"
+  }
+}
 
-# Index example docs
-POST /cars/transactions/_bulk
-{ "index": {}}
-{ "price" : 10000, "color" : "red", "make" : "honda", "sold" : "2014-10-28" }
-{ "index": {}}
-{ "price" : 20000, "color" : "red", "make" : "honda", "sold" : "2014-11-05" }
-{ "index": {}}
-{ "price" : 30000, "color" : "green", "make" : "ford", "sold" : "2014-05-18" }
-{ "index": {}}
-{ "price" : 15000, "color" : "blue", "make" : "toyota", "sold" : "2014-07-02" }
-{ "index": {}}
-{ "price" : 12000, "color" : "green", "make" : "toyota", "sold" : "2014-08-19" }
-{ "index": {}}
-{ "price" : 20000, "color" : "red", "make" : "honda", "sold" : "2014-11-05" }
-{ "index": {}}
-{ "price" : 80000, "color" : "red", "make" : "bmw", "sold" : "2014-01-01" }
-{ "index": {}}
-{ "price" : 25000, "color" : "blue", "make" : "ford", "sold" : "2014-02-12" }
+# Inspect the repo to see what snapshots are available
+GET /_snapshot/taxis/_all
 
-# Basic aggregation - most popular car colors
-GET /cars/transactions/_search
+# Begin the Restore process
+POST /_snapshot/taxis/snapshot/_restore
+
+# Monitor the restore process as shards download
+GET /taxis/_recovery
+
+# Run a simple search to explore the data
+GET taxis/_search
+
+# Basic aggregation - rides per taxi vendor
+GET /taxis/_search
 {
     "size" : 0,
     "aggs" : {
-        "popular_colors" : {
+        "rides_per_vendor" : {
             "terms" : {
-              "field" : "color"
+              "field" : "vendor"
             }
         }
     }
 }
 
 
-# Find the average price of each car color
-GET /cars/transactions/_search
+# Find the average revenue per vendor
+GET /taxis/_search
 {
    "size" : 0,
    "aggs": {
-      "colors": {
+      "vendors": {
          "terms": {
-            "field": "color"
+            "field": "vendor"
          },
          "aggs": {
-            "avg_price": {
+            "avg_revenue": {
                "avg": {
-                  "field": "price"
+                  "field": "total_amount"
                }
             }
          }
@@ -55,54 +54,56 @@ GET /cars/transactions/_search
 }
 
 
-# Nest a second bucket to determine top makes per color
-GET /cars/transactions/_search
+# Nest a second bucket to determine passenger count per vendor
+GET /taxis/_search
 {
    "size" : 0,
    "aggs": {
-      "colors": {
+      "vendors": {
          "terms": {
-            "field": "color"
+            "field": "vendor"
          },
          "aggs": {
-            "avg_price": {
+            "avg_revenue": {
                "avg": {
-                  "field": "price"
+                  "field": "total_amount"
                }
             },
-            "make": {
-                "terms": {
-                    "field": "make"
-                }
+            "passengers": {
+              "terms": {
+                "field": "passenger_count"
+              }
             }
          }
       }
    }
 }
 
-
-# Finally, add some extra metrics to determine min/max price per-make, per-color
-GET /cars/transactions/_search
+# Finally, add some extra metrics to determine min/max tip per-vendor, per-passenger count
+GET /taxis/_search
 {
-   "size" : 0,
-   "aggs": {
-      "colors": {
-         "terms": {
-            "field": "color"
-         },
-         "aggs": {
-            "avg_price": { "avg": { "field": "price" }
-            },
-            "make" : {
-                "terms" : {
-                    "field" : "make"
-                },
-                "aggs" : {
-                    "min_price" : { "min": { "field": "price"} },
-                    "max_price" : { "max": { "field": "price"} } 
-                }
-            }
-         }
+  "size": 0,
+  "aggs": {
+    "vendors": {
+      "terms": {
+        "field": "vendor"
+      },
+      "aggs": {
+        "avg_revenue": {
+          "avg": {
+            "field": "total_amount"
+          }
+        },
+        "passengers": {
+          "terms": {
+            "field": "passenger_count"
+          },
+          "aggs": {
+            "min_tip": { "min": { "field": "tip_amount" } },
+            "max_tip": { "max": { "field": "tip_amount" } }
+          }
+        }
       }
-   }
+    }
+  }
 }


### PR DESCRIPTION
This is a work-in-progress of all the sections that refer to `snippets/300_Aggregations/20_basic_example.json`. It is using our newly generated taxis dataset and I tried to stick as closely as possible to the previous example. 

However, I am not happy at the moment with the distribution of data. One example: All taxi vendors have a similar amount of rides and also a very similar revenue which makes the examples less useful IMHO. Hence, I'd put some effort into the generator script to introduce more variance across vendors.

Apart from that, I think it is now in a state where it's useful to get some initial feedback.

