### PR TITLE
fixed the wrong quote for `full text search` section

### DIFF
--- a/010_Intro/30_Tutorial_Search.asciidoc
+++ b/010_Intro/30_Tutorial_Search.asciidoc
@@ -281,7 +281,7 @@ GET /megacorp/employee/_search
 // SENSE: 010_Intro/30_Query_DSL.json
 
 You can see that we use the same `match` query as before to search the `about`
-field for ``rock climbing''. We get back two matching documents:
+field for `rock climbing`. We get back two matching documents:
 
 [source,js]
 --------------------------------------------------


### PR DESCRIPTION
Fixed the wrong quoting for full text search section, updated the ```rock climbing''` to `rock climbing`

<!--
Thanks for the Pull Request!  We really appreciate your help and contribution!

Before you submit the PR, have you signed Contributor License Agreement: https://www.elastic.co/contributor-agreement/ ?

PR's (no matter how small) cannot be merged until the CLA has been signed.  
It only needs to be signed once, however. Thanks!
-->
