### PR TITLE
Update 35_Tutorial_Aggregations.asciidoc

### DIFF
--- a/010_Intro/35_Tutorial_Aggregations.asciidoc
+++ b/010_Intro/35_Tutorial_Aggregations.asciidoc
@@ -13,7 +13,7 @@ GET /megacorp/employee/_search
 {
   "aggs": {
     "all_interests": {
-      "terms": { "field": "interests" }
+      "terms": { "field": "interests.keyword" }
     }
   }
 }
@@ -102,7 +102,7 @@ GET /megacorp/employee/_search
 {
     "aggs" : {
         "all_interests" : {
-            "terms" : { "field" : "interests" },
+            "terms" : { "field" : "interests.keyword" },
             "aggs" : {
                 "avg_age" : {
                     "avg" : { "field" : "age" }


### PR DESCRIPTION
Executing aggergations on interests will result in an error by default : "Fielddata is disabled on text fields by default....
You don't want to enable fielddata for good reason, instead you want to perform the aggregation on the interests.keyword field, which will return the same result without enabling fielddata.

<!--
Thanks for the Pull Request!  We really appreciate your help and contribution!

Before you submit the PR, have you signed Contributor License Agreement: https://www.elastic.co/contributor-agreement/ ?

PR's (no matter how small) cannot be merged until the CLA has been signed.  
It only needs to be signed once, however. Thanks!
-->
