### PR TITLE
Add warning about the default limit of processors

### DIFF
--- a/510_Deployment/20_hardware.asciidoc
+++ b/510_Deployment/20_hardware.asciidoc
@@ -31,7 +31,7 @@ choose a modern processor with multiple cores.  Common clusters utilize two- to 
 
 If you need to choose between faster CPUs or more cores, choose more cores.  The
 extra concurrency that multiple cores offers will far outweigh a slightly faster
-clock speed.
+clock speed. Note that the number of processors is by default bounded to 32.
 
 ==== Disks
 


### PR DESCRIPTION
The default limit of processors can be tricky. This change will avoid some confusion about running elasticsearch on machines with more than 32 processors.

<!--
Thanks for the Pull Request!  We really appreciate your help and contribution!

Before you submit the PR, have you signed Contributor License Agreement: https://www.elastic.co/contributor-agreement/ ?

PR's (no matter how small) cannot be merged until the CLA has been signed.  
It only needs to be signed once, however. Thanks!
-->
