### PR TITLE
Correct false statement about terms equivalent to multiple term

### DIFF
--- a/080_Structured_Search/15_terms.asciidoc
+++ b/080_Structured_Search/15_terms.asciidoc
@@ -5,9 +5,9 @@ to search for multiple values.((("exact values", "finding multiple")))
 ((("structured search", "finding multiple exact values")))  What if you want to
 find documents that have a price of $20 or $30?
 
-Rather than using multiple `term` queries, you can instead use a single `terms`
-query (note the _s_ at the end).  The `terms` query((("terms query"))) is simply the plural
-version of the singular `term` query cousin.
+The `terms` query((("terms query"))) is useful to find documents which contain
+any of the exact terms specified. Whereas multiple `term` queries would find
+documents which contain all of them.
 
 It looks nearly identical to a vanilla `term` too.  Instead of
 specifying a single price, we are now specifying an array of values:


### PR DESCRIPTION
Hi,

Unless I'm terribly mistaken, the following statement is false:

> Rather than using multiple `term` queries, you can instead use a single `terms` query (note the s at the end). The `terms` query is simply the plural version of the singular `term` query cousin.

Consider the following queries:

```json
{
	"query": {
		"bool": {
			"filter": [
				{ "term": { "tags": "under-30-minutes" } },
				{ "term": { "tags": "vegetarian" } }
			]
		}
	}
}
```
```json
{
	"query": {
		"bool": {
			"filter": {
				"terms": { "tags": [ "under-30-minutes", "vegetarian" ] } 
			}
		}
	}
}
```

The first one matches documents that have both tags, whereas the second one matches documents that have any of them. This is different behavior. Therefore a `terms` query is not equal to multiple `term` queries.

https://github.com/elastic/elasticsearch-definitive-guide/blob/2.x/080_Structured_Search/15_terms.asciidoc