### PR TITLE
Add synced flush step to rolling restart guide

### DIFF
--- a/520_Post_Deployment/40_rolling_restart.asciidoc
+++ b/520_Post_Deployment/40_rolling_restart.asciidoc
@@ -20,8 +20,15 @@ What we want to do is tell Elasticsearch to hold off on rebalancing, because
 we have more knowledge about the state of the cluster due to external factors.
 The procedure is as follows:
 
-1. If possible, stop indexing new data.  This is not always possible, but will
-help speed up recovery time.
+1. If possible, stop indexing new data and perform a synced flush. This is not
+always possible, but will help speed up recovery time. A synced flush request is
+a “best effort” operation. It will fail if there are any pending indexing
+operations, but it is safe to reissue the request multiple times if necessary.
++
+[source,js]
+----
+POST /_flush/synced
+----
 
 2. Disable shard allocation.  This prevents Elasticsearch from rebalancing
 missing shards until you tell it otherwise.  If you know the maintenance window will be


### PR DESCRIPTION
The unstable branch of the docs already has this step, but the branch listed as "2.x (current)" on the docs site hasn't had this step backported to it yet.
