### PR TITLE
Replace tribe reference with cross cluster search

### DIFF
--- a/410_Scaling/80_Scale_is_not_infinite.asciidoc
+++ b/410_Scaling/80_Scale_is_not_infinite.asciidoc
@@ -83,5 +83,5 @@ small and agile.
 Eventually, despite your best intentions, you may find that the number of
 nodes and indices and mappings that you have is just too much for one cluster.
 At this stage, it is probably worth dividing the problem into multiple
-clusters.  Thanks to {ref}/modules-tribe.html[`tribe` nodes], you can even run
+clusters.  Thanks to {ref}/cross-cluster-search.html[cross cluster search], you can even run
 searches across multiple clusters, as if they were one big cluster.


### PR DESCRIPTION
tribe is not considered the right solution for cross cluster search access. It's been deprecated since 5.4
