### PR TITLE
Change the word '_all' by all

### DIFF
--- a/054_Query_DSL/55_Request_body_search.asciidoc
+++ b/054_Query_DSL/55_Request_body_search.asciidoc
@@ -26,7 +26,7 @@ GET /_search
 // SENSE: 054_Query_DSL/60_Empty_query.json
 <1> This is an empty request body.
 
-Just as with a query-string search, you can search on one, many, or `_all`
+Just as with a query-string search, you can search on one, many, or all
 indices, and one, many, or all types:
 
 [source,js]


### PR DESCRIPTION
As far as I understand '_all' is a field in every document, and here does not make sense

<!--
Thanks for the Pull Request!  We really appreciate your help and contribution!

Before you submit the PR, have you signed Contributor License Agreement: https://www.elastic.co/contributor-agreement/ ?

PR's (no matter how small) cannot be merged until the CLA has been signed.  
It only needs to be signed once, however. Thanks!
-->
