### PR TITLE
Update 05_term.asciidoc

### DIFF
--- a/080_Structured_Search/05_term.asciidoc
+++ b/080_Structured_Search/05_term.asciidoc
@@ -222,7 +222,6 @@ PUT /my_store <2>
             }
         }
     }
-
 }
 --------------------------------------------------
 // SENSE: 080_Structured_Search/05_Term_text.json


### PR DESCRIPTION
removed an empty line causing cut&paste for CURL version to not copy the last closing bracket: `}` generating an invalid JSON.
