### PR TITLE
Update 10_Installing_ES.asciidoc

### DIFF
--- a/010_Intro/10_Installing_ES.asciidoc
+++ b/010_Intro/10_Installing_ES.asciidoc
@@ -100,7 +100,7 @@ Elasticsearch cluster.
 +
 [source,sh]
 --------------------------------------------------
-./bin/kibana plugin --install elastic/sense <1>
+./bin/kibana-plugin --install elastic/sense <1>
 --------------------------------------------------
 <1> Windows: `bin\kibana.bat plugin --install elastic/sense`.
 +


### PR DESCRIPTION
According to the docs, as of kibana 5.0, the command to install plugins is `kibana-plugin`.