### PR TITLE
Update description of match query

### DIFF
--- a/010_Intro/30_Tutorial_Search.asciidoc
+++ b/010_Intro/30_Tutorial_Search.asciidoc
@@ -265,7 +265,7 @@ The searches so far have been simple:  single names, filtered by age. Let's
 try a more advanced, full-text search--a ((("full text search")))task that traditional databases
 would really struggle with.
 
-We are going to search for all employees who enjoy rock climbing:
+We are going to search for all employees who enjoy rock or climbing:
 
 [source,js]
 --------------------------------------------------


### PR DESCRIPTION
Previous description was "We are going to search for all employees who enjoy rock climbing", it says us that we do match_phrase, but actually we do or operation for each word.

<!--
Thanks for the Pull Request!  We really appreciate your help and contribution!

Before you submit the PR, have you signed Contributor License Agreement: https://www.elastic.co/contributor-agreement/ ?

PR's (no matter how small) cannot be merged until the CLA has been signed.  
It only needs to be signed once, however. Thanks!
-->
