### PR TITLE
Clarify that term filters are not cached

### DIFF
--- a/080_Structured_Search/05_term.asciidoc
+++ b/080_Structured_Search/05_term.asciidoc
@@ -321,5 +321,7 @@ you can conceptually think of non-scoring queries as executing _before_ the scor
 queries.  The job of non-scoring queries is to reduce the number of documents that
 the more costly scoring queries need to evaluate, resulting in a faster search request.
 
+Note: Term queries are not cached as of version 5.x because they are already quite fast. See this link [https://github.com/elastic/elasticsearch/issues/16031]
+
 By conceptually thinking of non-scoring queries as executing first, you'll be
 equipped to write efficient and fast search requests.


### PR DESCRIPTION
Term filters are no longer cached, so it's best to tell it upfront.

<!--
Thanks for the Pull Request!  We really appreciate your help and contribution!

Before you submit the PR, have you signed Contributor License Agreement: https://www.elastic.co/contributor-agreement/ ?

PR's (no matter how small) cannot be merged until the CLA has been signed.  
It only needs to be signed once, however. Thanks!
-->
