### PR TITLE
Update 50_heap.asciidoc

### DIFF
--- a/510_Deployment/50_heap.asciidoc
+++ b/510_Deployment/50_heap.asciidoc
@@ -219,5 +219,5 @@ Finally, if neither approach is possible, you should enable `mlockall`. file.
 
 [source,yaml]
 ----
-bootstrap.mlockall: true
+bootstrap.memory_lock: true
 ----


### PR DESCRIPTION
bootstrap.mlockall is now bootstrap.memory_lock

https://www.elastic.co/guide/en/elasticsearch/reference/current/setup-configuration-memory.html
