### PR TITLE
Using keyword instead of text for field color

### DIFF
--- a/300_Aggregations/20_basic_example.asciidoc
+++ b/300_Aggregations/20_basic_example.asciidoc
@@ -52,7 +52,7 @@ GET /cars/transactions/_search
     "aggs" : { <1>
         "popular_colors" : { <2>
             "terms" : { <3>
-              "field" : "color"
+              "field" : "color.keyword"
             }
         }
     }


### PR DESCRIPTION
Getting an error message on Kibana console 6.4.2
"error": {
    "root_cause": [
      {
        "type": "illegal_argument_exception",
        "reason": "Fielddata is disabled on text fields by default. Set fielddata=true on [color] in order to load fielddata in memory by uninverting the inverted index. Note that this can however use significant memory. Alternatively use a keyword field instead."
      }
    ]

<!--
Thanks for the Pull Request!  We really appreciate your help and contribution!

Before you submit the PR, have you signed Contributor License Agreement: https://www.elastic.co/contributor-agreement/ ?

PR's (no matter how small) cannot be merged until the CLA has been signed.  
It only needs to be signed once, however. Thanks!
-->
