### PR TITLE
Update31_Nested_mapping.asciidoc - wrong type

### DIFF
--- a/402_Nested/31_Nested_mapping.asciidoc
+++ b/402_Nested/31_Nested_mapping.asciidoc
@@ -14,8 +14,8 @@ PUT /my_index
         "comments": {
           "type": "nested", <1>
           "properties": {
-            "name":    { "type": "string"  },
-            "comment": { "type": "string"  },
+            "name":    { "type": "text"  },
+            "comment": { "type": "text"  },
             "age":     { "type": "short"   },
             "stars":   { "type": "short"   },
             "date":    { "type": "date"    }


### PR DESCRIPTION
string is not an excepted type.  text is the correct type.

<!--
Thanks for the Pull Request!  We really appreciate your help and contribution!

Before you submit the PR, have you signed Contributor License Agreement: https://www.elastic.co/contributor-agreement/ ?

PR's (no matter how small) cannot be merged until the CLA has been signed.  
It only needs to be signed once, however. Thanks!
-->
