### PR TITLE
[DOCS] Fix broken link for 7.0 release

### DIFF
--- a/510_Deployment/40_config.asciidoc
+++ b/510_Deployment/40_config.asciidoc
@@ -270,6 +270,6 @@ a day. This setting is configured in `elasticsearch.yml`:
 discovery.zen.ping.unicast.hosts: ["host1", "host2:port"]
 ----
 
-For more information about how Elasticsearch nodes find eachother, see
-https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-discovery-zen.html[Zen Discovery]
+For more information about how Elasticsearch nodes find each other, see
+{ref}/modules-discovery.html[Discovery and cluster formation]
 in the Elasticsearch Reference.


### PR DESCRIPTION
Fixes a broken link in [Important Configuration Changes](https://www.elastic.co/guide/en/elasticsearch/guide/2.x/important-configuration-changes.html) for v7.0 release.