### PR TITLE
[DOCS] Remove relative `/current` links to Elasticsearch Reference Guide

### DIFF
--- a/070_Index_Mgmt/20_Custom_Analyzers.asciidoc
+++ b/070_Index_Mgmt/20_Custom_Analyzers.asciidoc
@@ -48,7 +48,7 @@ After tokenization, the resulting _token stream_ is passed through any
 specified token filters,((("token filters"))) in the order in which they are specified.
 
 Token filters may change, add, or remove tokens.  We have already mentioned the
-http://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-lowercase-tokenizer.html[`lowercase`] and
+{ref}/analysis-lowercase-tokenizer.html[`lowercase`] and
 {ref}/analysis-stop-tokenfilter.html[`stop` token filters],
 but there are many more available in Elasticsearch.
 {ref}/analysis-stemmer-tokenfilter.html[Stemming token filters]

--- a/200_Language_intro/00_Intro.asciidoc
+++ b/200_Language_intro/00_Intro.asciidoc
@@ -2,7 +2,7 @@
 == Getting Started with Languages
 
 Elasticsearch ships with a collection of language analyzers that provide
-good, basic, https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-lang-analyzer.html[out-of-the-box support]
+good, basic, {ref}/analysis-lang-analyzer.html[out-of-the-box support]
 for many of the world's most common languages.
 
 These analyzers typically perform four roles:

--- a/230_Stemming/60_Stemming_in_situ.asciidoc
+++ b/230_Stemming/60_Stemming_in_situ.asciidoc
@@ -19,7 +19,7 @@ Pos 4: (jumped,jump) <1>
 WARNING: Read <<stemming-in-situ-good-idea>> before using this approach.
 
 To achieve stemming _in situ_, we will use the
-http://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-keyword-repeat-tokenfilter.html[`keyword_repeat`]
+{ref}/analysis-keyword-repeat-tokenfilter.html[`keyword_repeat`]
 token filter,((("keyword_repeat token filter"))) which, like the `keyword_marker` token filter (see
 <<preventing-stemming>>), marks each term as a keyword to prevent the subsequent
 stemmer from touching it.  However, it also repeats the term in the same

--- a/240_Stopwords/40_Divide_and_conquer.asciidoc
+++ b/240_Stopwords/40_Divide_and_conquer.asciidoc
@@ -188,5 +188,5 @@ documents that have 75% of all high-frequency terms with a query like this:
 }
 ---------------------------------
 
-See the https://www.elastic.co/guide/en/elasticsearch/reference/2.4/query-dsl-common-terms-query.html[`common` terms query] reference page for more options.
+See the {ref}/query-dsl-common-terms-query.html[`common` terms query] reference page for more options.
 

--- a/300_Aggregations/100_circuit_breaker_fd_settings.asciidoc
+++ b/300_Aggregations/100_circuit_breaker_fd_settings.asciidoc
@@ -135,7 +135,7 @@ indicate a serious resource issue and a reason for poor performance.
 
 Fielddata usage can be monitored:
 
-* per-index using the http://www.elastic.co/guide/en/elasticsearch/reference/current/indices-stats.html[`indices-stats` API]:
+* per-index using the {ref}/indices-stats.html[`indices-stats` API]:
 +
 [source,json]
 -------------------------------

--- a/404_Parent_Child/60_Children_agg.asciidoc
+++ b/404_Parent_Child/60_Children_agg.asciidoc
@@ -2,7 +2,7 @@
 === Children Aggregation
 
 Parent-child supports a
-http://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-children-aggregation.html[`children` aggregation]  as ((("aggregations", "children aggregation")))((("children aggregation")))((("parent-child relationship", "children aggregation")))a direct analog to the `nested` aggregation discussed in
+{ref}/search-aggregations-bucket-children-aggregation.html[`children` aggregation]  as ((("aggregations", "children aggregation")))((("children aggregation")))((("parent-child relationship", "children aggregation")))a direct analog to the `nested` aggregation discussed in
 <<nested-aggregation>>.  A parent aggregation (the equivalent of
 `reverse_nested`) is not supported.
 

--- a/book.asciidoc
+++ b/book.asciidoc
@@ -1,6 +1,6 @@
 :bookseries: animal
 :es_build:   1
-:ref: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref: https://www.elastic.co/guide/en/elasticsearch/reference/2.4
 
 = Elasticsearch: The Definitive Guide
 


### PR DESCRIPTION
The `/current` branch of the Elasticsearch Reference Guide changes frequently.
Links to that branch of the documentation often break as pages are removed.

This changes most `/current` links to use the `2.4` branch.

Resolves #789.