### PR TITLE
[DOCS] Remove "we're updating this book" note.

### DIFF
--- a/book-docinfo.xml
+++ b/book-docinfo.xml
@@ -1,4 +1,3 @@
-<?page_header <b>PLEASE NOTE:</b><br/>We are working on updating this book for the latest version. Some content might be out of date.?>
 
 <legalnotice>
   <simpara>
@@ -15,9 +14,6 @@
 <edition>Elasticsearch: The Definitive Guide, Second Edition</edition>
 
 <abstract>
-    <simpara role="page_header">
-      We are working on updating this book for the latest version. Some content might be out of date.
-    </simpara>
     <simpara>
         If you would like to purchase an eBook or printed version of this
         book once it is complete, you can do so from O'Reilly Media:


### PR DESCRIPTION
As of writing, there are no plans to update the Definitive Guide for
Elasticsearch versions past 2.4.

Relates to https://github.com/elastic/elasticsearch-definitive-guide/pull/790#issuecomment-497835515.