### PR TITLE
Fix for #703

### DIFF
--- a/510_Deployment/50_heap.asciidoc
+++ b/510_Deployment/50_heap.asciidoc
@@ -74,7 +74,7 @@ is more wasted space simply because the pointer is larger.  And worse than waste
 space, the larger pointers eat up more bandwidth when moving values between
 main memory and various caches (LLC, L1, and so forth).
 
-Java uses a trick called https://wikis.oracle.com/display/HotSpotInternals/CompressedOops[compressed oops]((("compressed object pointers")))
+Java uses a trick called https://wiki.openjdk.java.net/display/HotSpot/CompressedOops[compressed oops]((("compressed object pointers")))
 to get around this problem.  Instead of pointing at exact byte locations in
 memory, the pointers reference _object offsets_.((("object offsets")))  This means a 32-bit pointer can
 reference four billion _objects_, rather than four billion bytes.  Ultimately, this


### PR DESCRIPTION
As discussed on #703, there is a dead link to the Oracle wiki. The [original page](http://web.archive.org/web/20150204134523/https://wikis.oracle.com/display/HotSpotInternals/CompressedOops) moved [here](https://wiki.openjdk.java.net/display/HotSpot/CompressedOops).

<!--
Thanks for the Pull Request!  We really appreciate your help and contribution!

Before you submit the PR, have you signed Contributor License Agreement: https://www.elastic.co/contributor-agreement/ ?

PR's (no matter how small) cannot be merged until the CLA has been signed.  
It only needs to be signed once, however. Thanks!
-->
